### PR TITLE
docs: remind of Denfition of Done in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+{What changes? Why?}
+
+
+----
+
+[Definition of Done][]
+
+<!-- Intended as a low-intrusion quick checklist reminder of Definition of Done.
+     Routinely, take the opportunity to reflect and then tick off the did-the-right-thing-for items.
+     Exceptionally, explain what's exceptional why.
+-->
+
+- [ ] Documented
+- [ ] Fails gracefully
+- [ ] Tested
+- [ ] Secure
+- [ ] Adds no defects
+- [ ] Shippable. Path is clear to promote to production
+- [ ] Maintainable
+- [ ] Configurable
+- [ ] Readable
+- [ ] Validates and sanitizes user input
+- [ ] Styled
+
+[Definition of Done]: https://goo.gl/4JG2Z5


### PR DESCRIPTION
Experiment: 

What if we remind ourselves of the (MyUW) Definition of Done in the Pull Request template?

Might it be easy, low friction enough, fun even to tick off the angles we've thoughtfully considered in a changeset?

Might the regular reminder about our Definition of Done encourage us to tighten up the definition to whatever we're really committed to thinking about in each change (and nothing else)?