### PR TITLE
MYUWMSG-9 Filter by groups

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-## uportal-messages
+# uportal-messages
 
 This messaging microservice is intended for use with [uportal-home](https://github.com/uPortal-Project/uportal-home).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,3 @@
-
-
 ## uportal-messages
 
 This messaging microservice is intended for use with [uportal-home](https://github.com/uPortal-Project/uportal-home).

--- a/src/main/java/edu/wisc/my/messages/controller/IsMemberOfHeaderParser.java
+++ b/src/main/java/edu/wisc/my/messages/controller/IsMemberOfHeaderParser.java
@@ -1,0 +1,30 @@
+package edu.wisc.my.messages.controller;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Utility for parsing isMemberOf header.
+ */
+@Component
+public class IsMemberOfHeaderParser {
+
+    public Set<String> groupsFromHeaderValue(String headerValue) {
+
+        if (null == headerValue) {
+            return Collections.EMPTY_SET;
+        }
+
+        Set<String> userGroups = new HashSet<>();
+
+        String[] groupsArray = headerValue.split(";");
+        userGroups.addAll( Arrays.asList(groupsArray) );
+
+        return userGroups;
+    }
+}

--- a/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
+++ b/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
@@ -22,7 +22,7 @@ public class MessagesController {
     @RequestMapping(value="/messages", method=RequestMethod.GET)
     public @ResponseBody void messages(HttpServletRequest request,
         HttpServletResponse response) {
-            JSONObject json = messagesService.getRawMessages();
+            JSONObject json = messagesService.allMessages();
             response.setContentType("application/json");
             try {
                 response.getWriter().write(json.toString());
@@ -35,7 +35,7 @@ public class MessagesController {
     @RequestMapping(value = "/currentMessages", method = RequestMethod.GET)
     public @ResponseBody void currentMessages(HttpServletRequest request, HttpServletResponse response) {
         response.setContentType("application/json");
-        JSONObject messages = messagesService.getDateFilteredMessages();
+        JSONObject messages = messagesService.filteredMessages();
         try {
             response.getWriter().write(messages.toString());
             response.setStatus(HttpServletResponse.SC_OK);

--- a/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
+++ b/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
@@ -3,6 +3,7 @@ package edu.wisc.my.messages.controller;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import edu.wisc.my.messages.model.User;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,10 +15,16 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 import edu.wisc.my.messages.service.MessagesService;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 @Controller
 public class MessagesController {
     protected final Logger logger = LoggerFactory.getLogger(getClass());
+
     private MessagesService messagesService;
+    private IsMemberOfHeaderParser isMemberOfHeaderParser;
     
     @RequestMapping(value="/messages", method=RequestMethod.GET)
     public @ResponseBody void messages(HttpServletRequest request,
@@ -35,7 +42,13 @@ public class MessagesController {
     @RequestMapping(value = "/currentMessages", method = RequestMethod.GET)
     public @ResponseBody void currentMessages(HttpServletRequest request, HttpServletResponse response) {
         response.setContentType("application/json");
-        JSONObject messages = messagesService.filteredMessages();
+
+        String isMemberOfHeader = request.getHeader("isMemberOf");
+        Set<String> groups = isMemberOfHeaderParser.groupsFromHeaderValue(isMemberOfHeader);
+        User user = new User();
+        user.setGroups(groups);
+
+        JSONObject messages = messagesService.filteredMessages(user);
         try {
             response.getWriter().write(messages.toString());
             response.setStatus(HttpServletResponse.SC_OK);
@@ -62,6 +75,11 @@ public class MessagesController {
     @Autowired
     public void setMessagesService(MessagesService messagesService) {
         this.messagesService = messagesService;
+    }
+
+    @Autowired
+    public void setIsMemberOfHeaderParser(IsMemberOfHeaderParser isMemberOfHeaderParser) {
+        this.isMemberOfHeaderParser = isMemberOfHeaderParser;
     }
 
 }

--- a/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
+++ b/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
@@ -58,7 +58,8 @@ public class MessagesController {
         response.setContentType("application/json");
 
         String isMemberOfHeader = request.getHeader("isMemberOf");
-        Set<String> groups = isMemberOfHeaderParser.groupsFromHeaderValue(isMemberOfHeader);
+        Set<String> groups =
+                isMemberOfHeaderParser.groupsFromHeaderValue(isMemberOfHeader);
         User user = new User();
         user.setGroups(groups);
 
@@ -105,7 +106,8 @@ public class MessagesController {
     }
 
     @Autowired
-    public void setIsMemberOfHeaderParser(IsMemberOfHeaderParser isMemberOfHeaderParser) {
+    public void setIsMemberOfHeaderParser(
+            IsMemberOfHeaderParser isMemberOfHeaderParser) {
         this.isMemberOfHeaderParser = isMemberOfHeaderParser;
     }
 

--- a/src/main/java/edu/wisc/my/messages/data/MessagesFromTextFile.java
+++ b/src/main/java/edu/wisc/my/messages/data/MessagesFromTextFile.java
@@ -1,0 +1,49 @@
+package edu.wisc.my.messages.data;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.wisc.my.messages.model.Message;
+import edu.wisc.my.messages.model.MessageArray;
+import org.apache.commons.io.IOUtils;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.stereotype.Repository;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+
+@Repository
+public class MessagesFromTextFile {
+
+    @Autowired
+    private ResourceLoader resourceLoader;
+
+    @Autowired
+    private Environment env;
+
+    public List<Message> allMessages() {
+
+        try {
+            Resource resource = resourceLoader.getResource(env.getProperty("message.source"));
+            InputStream is = resource.getInputStream();
+            String jsonTxt = IOUtils.toString(is, "UTF-8");
+            JSONObject json = new JSONObject(jsonTxt);
+
+            ObjectMapper mapper = new ObjectMapper();
+
+            MessageArray messageArray = mapper.readValue(json.toString(), MessageArray.class);
+
+            return Arrays.asList(messageArray.getMessages());
+
+        } catch (IOException exception) {
+            throw new RuntimeException("Unable to load messages from text file.", exception);
+        }
+
+
+    }
+
+}

--- a/src/main/java/edu/wisc/my/messages/model/AudienceFilter.java
+++ b/src/main/java/edu/wisc/my/messages/model/AudienceFilter.java
@@ -1,10 +1,10 @@
 package edu.wisc.my.messages.model;
 
-import java.util.Objects;
+import java.util.*;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import java.util.ArrayList;
-import java.util.List;
+
 import javax.validation.constraints.*;
 /**
  * AudienceFilter
@@ -70,5 +70,14 @@ public class AudienceFilter   {
     }
     return o.toString().replace("\n", "\n    ");
   }
-}
 
+  public boolean matches(User user) {
+
+    Set<String> requireAtLeastOneOfTheseGroups = new HashSet<>();
+    requireAtLeastOneOfTheseGroups.addAll(this.groups);
+
+    requireAtLeastOneOfTheseGroups.retainAll(user.getGroups());
+
+    return ( ! requireAtLeastOneOfTheseGroups.isEmpty());
+  }
+}

--- a/src/main/java/edu/wisc/my/messages/model/AudienceFilter.java
+++ b/src/main/java/edu/wisc/my/messages/model/AudienceFilter.java
@@ -1,16 +1,22 @@
 package edu.wisc.my.messages.model;
 
 import java.util.*;
+import java.util.function.Predicate;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import javax.validation.constraints.*;
-/**
- * AudienceFilter
- */
 
-public class AudienceFilter   {
+/**
+ * Predicate over User, answering whether the User is or is not in the Audience.
+ *
+ * Currently AudienceFilter only knows how to consider whether a User is a
+ * member of at least one of the required groups for a message. Conceptually
+ * other varieties of AudienceFilters might be possible.
+ */
+public class AudienceFilter
+  implements Predicate<User> {
   @JsonProperty("groups")
   private List<String> groups = new ArrayList<String>();
 
@@ -71,7 +77,8 @@ public class AudienceFilter   {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public boolean matches(User user) {
+  @Override
+  public boolean test(User user) {
 
     Set<String> requireAtLeastOneOfTheseGroups = new HashSet<>();
     requireAtLeastOneOfTheseGroups.addAll(this.groups);

--- a/src/main/java/edu/wisc/my/messages/model/MessageArray.java
+++ b/src/main/java/edu/wisc/my/messages/model/MessageArray.java
@@ -1,7 +1,17 @@
 package edu.wisc.my.messages.model;
 
+import java.util.List;
+
 public class MessageArray {
     private Message[] messages;
+
+    public MessageArray(){
+    }
+
+    public MessageArray(List<Message> someMessages) {
+        Message[] arrayExample = {};
+        this.messages = someMessages.toArray(arrayExample);
+    }
 
     public Message[] getMessages(){
         return this.messages;

--- a/src/main/java/edu/wisc/my/messages/model/User.java
+++ b/src/main/java/edu/wisc/my/messages/model/User.java
@@ -1,0 +1,32 @@
+package edu.wisc.my.messages.model;
+
+import org.apache.commons.lang.Validate;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class User {
+
+    /**
+     * Get the groups of which the user is a member.
+     * @return potentially empty Set
+     */
+    public Set<String> getGroups() {
+        return groups;
+    }
+
+    /**
+     * Set the groups of which the user is a member.
+     * @param groups non-null potentially empty Set
+     */
+    public void setGroups(Set<String> groups) {
+        Validate.notNull(groups);
+        this.groups = groups;
+    }
+
+    /**
+     * The groups of which the user is a member.
+     */
+    private Set<String> groups = new HashSet<>();
+
+}

--- a/src/main/java/edu/wisc/my/messages/service/MessagesService.java
+++ b/src/main/java/edu/wisc/my/messages/service/MessagesService.java
@@ -46,21 +46,27 @@ public class MessagesService {
         }
     }
 
-    public JSONObject filteredMessages() {
+    public JSONObject filteredMessages(User user) {
         JSONObject validMessages = new JSONObject();
         JSONArray validMessageArray = new JSONArray();
         ObjectMapper mapper = new ObjectMapper();
 
+        // needed this to get unit test working to support refactoring JSON out of the service layer
+        // at which point won't need this to unit test service layer.
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+
         try {
             for (Message message : messageSource.allMessages()) {
-                if (message.isValidToday()) {
+                if (message.isValidToday()
+                        && ((null == message.getAudienceFilter() || message.getAudienceFilter().matches(user) ) )
+                    ) {
                     JSONObject validMessage = new JSONObject(message);
                     validMessageArray.put(validMessage);
                 }
             }
             validMessages.put("messages", validMessageArray);
         } catch (Exception e) {
-            logger.warn("Date filter failure " + e.getMessage());
+            logger.warn("Date filter failure ", e);
             return null;
         }
         return validMessages;

--- a/src/main/java/edu/wisc/my/messages/service/MessagesService.java
+++ b/src/main/java/edu/wisc/my/messages/service/MessagesService.java
@@ -28,7 +28,7 @@ public class MessagesService {
     @Autowired
     private Environment env;
 
-    public JSONObject getRawMessages() {
+    public JSONObject allMessages() {
         try {
             Resource resource = resourceLoader.getResource(env.getProperty("message.source"));
             InputStream is = resource.getInputStream();
@@ -45,8 +45,8 @@ public class MessagesService {
         }
     }
 
-    public JSONObject getDateFilteredMessages() {
-        JSONObject rawMessages = getRawMessages();
+    public JSONObject filteredMessages() {
+        JSONObject rawMessages = allMessages();
         JSONObject validMessages = new JSONObject();
         JSONArray validMessageArray = new JSONArray();
         ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/edu/wisc/my/messages/service/MessagesService.java
+++ b/src/main/java/edu/wisc/my/messages/service/MessagesService.java
@@ -58,7 +58,7 @@ public class MessagesService {
         try {
             for (Message message : messageSource.allMessages()) {
                 if (message.isValidToday()
-                        && ((null == message.getAudienceFilter() || message.getAudienceFilter().matches(user) ) )
+                        && ((null == message.getAudienceFilter() || message.getAudienceFilter().test(user) ) )
                     ) {
                     JSONObject validMessage = new JSONObject(message);
                     validMessageArray.put(validMessage);
@@ -77,4 +77,3 @@ public class MessagesService {
         this.messageSource = messageSource;
     }
 }
-     

--- a/src/main/resources/messages.json
+++ b/src/main/resources/messages.json
@@ -262,6 +262,33 @@
           "label": "More info"
         },
         "confirmButton": null
+      },
+      {
+        "id": "has-no-audience-filter",
+        "title": "An announcement lacking an audience filter.",
+        "titleShort": "Not filtered by audience",
+        "description": "This announcement is not filtered by groups.",
+        "descriptionShort": "Not filtered by groups.",
+        "messageType": "announcement",
+        "goLiveDate": null,
+        "expireDate": null,
+        "featureImageUrl": null,
+        "priority": null,
+        "audienceFilter": null,
+        "data": {
+          "dataUrl": null,
+          "dataObject": null,
+          "dataArrayFilter": null
+        },
+        "actionButton": {
+          "label": "Add to home",
+          "url": "addToHome/open-apereo"
+        },
+        "moreInfoButton": {
+          "url": "https://www.apereo.org/content/2018-open-apereo-montreal-quebec",
+          "label": "More info"
+        },
+        "confirmButton": null
       }
     ]
   }

--- a/src/test/java/edu/wisc/my/messages/controller/IsMemberOfHeaderParserTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/IsMemberOfHeaderParserTest.java
@@ -1,0 +1,62 @@
+package edu.wisc.my.messages.controller;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+public class IsMemberOfHeaderParserTest {
+
+    @Test
+    public void parsesNullAsEmptySet() {
+        assertEquals(Collections.EMPTY_SET, new IsMemberOfHeaderParser().groupsFromHeaderValue(null));
+    }
+
+    @Test
+    public void parsesSingleGroupValue() {
+        String headerValue = "uw:domain:tools.advising.wisc.edu:advising_gateway_access";
+        Set<String> expected = new HashSet<>();
+        expected.add(headerValue);
+
+        assertEquals(expected, new IsMemberOfHeaderParser().groupsFromHeaderValue(headerValue));
+    }
+
+    @Test
+    public void parsesSemicolonTerminateSingleGroupValue() {
+        String headerValue = "uw:domain:tools.advising.wisc.edu:advising_gateway_access;";
+        Set<String> expected = new HashSet<>();
+        expected.add("uw:domain:tools.advising.wisc.edu:advising_gateway_access");
+
+        assertEquals(expected, new IsMemberOfHeaderParser().groupsFromHeaderValue(headerValue));
+    }
+
+    @Test
+    public void parsesManyValuedHeader() {
+        String headerValue = "uw:domain:my.wisc.edu:my_uw_administrators;" +
+                "uw:domain:ohr.wisc.edu:trems;" +
+                "uw:domain:ADI_STAR_TimeEntry:star_users;" +
+                "uw:domain:office365.wisc.edu:license_change_2016;" +
+                "uw:domain:ohr.wisc.edu:myuw pmdp;" +
+                "uw:domain:registrar.wisc.edu:emergency_info_admin;" +
+                "uw:domain:tools.advising.wisc.edu:advising_gateway_access;" +
+                "uw:domain:apps.mumaa.doit.wisc.edu:lumen_access;" +
+                "uw:domain:my.wisc.edu:my_uw_hr_officers";
+
+        Set<String> expected = new HashSet<>();
+        expected.add("uw:domain:my.wisc.edu:my_uw_administrators");
+        expected.add("uw:domain:ohr.wisc.edu:trems");
+        expected.add("uw:domain:ADI_STAR_TimeEntry:star_users");
+        expected.add("uw:domain:office365.wisc.edu:license_change_2016");
+        expected.add("uw:domain:ohr.wisc.edu:myuw pmdp");
+        expected.add("uw:domain:registrar.wisc.edu:emergency_info_admin");
+        expected.add("uw:domain:tools.advising.wisc.edu:advising_gateway_access");
+        expected.add("uw:domain:apps.mumaa.doit.wisc.edu:lumen_access");
+        expected.add("uw:domain:my.wisc.edu:my_uw_hr_officers");
+
+        assertEquals(expected, new IsMemberOfHeaderParser().groupsFromHeaderValue(headerValue));
+    }
+
+}

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
@@ -1,0 +1,79 @@
+package edu.wisc.my.messages.controller;
+
+import edu.wisc.my.messages.model.User;
+import edu.wisc.my.messages.service.MessagesService;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class MessagesControllerUnitTest {
+
+
+    /**
+     * Test that the controller reads isMemberOf header from the request, asking its IsMemberOfHeaderParser about it.
+     */
+    @Test
+    public void usesIsMemberOfHeader() {
+
+        MessagesService mockService = mock(MessagesService.class);
+        IsMemberOfHeaderParser mockParser = mock(IsMemberOfHeaderParser.class);
+
+        MessagesController controller = new MessagesController();
+        controller.setIsMemberOfHeaderParser(mockParser);
+        controller.setMessagesService(mockService);
+
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+        JSONObject mockJsonObject = mock(JSONObject.class);
+
+        when(mockRequest.getHeader("isMemberOf")).thenReturn("group1;group2;");
+        when(mockService.filteredMessages(any())).thenReturn(mockJsonObject);
+
+        controller.currentMessages(mockRequest, mockResponse);
+
+        verify(mockRequest).getHeader("isMemberOf");
+        verify(mockParser).groupsFromHeaderValue("group1;group2;");
+
+    }
+
+    /**
+     * Test that the controller passes on to the Service the groups it learned from its IsMemberOfHeaderParser.
+     */
+    @Test
+    public void passesGroupsToService() {
+
+        MessagesService mockService = mock(MessagesService.class);
+        IsMemberOfHeaderParser mockParser = mock(IsMemberOfHeaderParser.class);
+
+        MessagesController controller = new MessagesController();
+        controller.setIsMemberOfHeaderParser(mockParser);
+        controller.setMessagesService(mockService);
+
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+        JSONObject mockJsonObject = mock(JSONObject.class);
+
+        when(mockService.filteredMessages(any())).thenReturn(mockJsonObject);
+        Set<String> groups = new HashSet<>();
+        groups.add("someGroup");
+        groups.add("someOtherGroup");
+        groups.add("yetAnotherGroup");
+        when(mockParser.groupsFromHeaderValue(anyString())).thenReturn(groups);
+
+        controller.currentMessages(mockRequest, mockResponse);
+
+        ArgumentCaptor<User> argument = ArgumentCaptor.forClass(User.class);
+        verify(mockService).filteredMessages(argument.capture());
+        assertEquals(groups, argument.getValue().getGroups());
+    }
+
+}

--- a/src/test/java/edu/wisc/my/messages/model/AudienceFilterTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/AudienceFilterTest.java
@@ -1,0 +1,42 @@
+package edu.wisc.my.messages.model;
+
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+public class AudienceFilterTest {
+
+    @Test
+    public void matchesWhenUserIsInAMatchingGroup() {
+        AudienceFilter filter = new AudienceFilter();
+        filter.addGroupsItem("matchingGroup");
+        filter.addGroupsItem("someOtherGroup");
+
+        final User user = new User();
+        Set<String> groups = new HashSet<>();
+        groups.add("matchingGroup");
+        groups.add("unrelatedGroup");
+        user.setGroups(groups);
+
+        assertTrue(filter.matches(user));
+    }
+
+    @Test
+    public void doesNotMatchWhenUserIsInNoMatchingGroup() {
+        AudienceFilter filter = new AudienceFilter();
+        filter.addGroupsItem("someGroup");
+        filter.addGroupsItem("someOtherGroup");
+
+        final User user = new User();
+        Set<String> groups = new HashSet<>();
+        groups.add("notMatchingGroup");
+        groups.add("unrelatedGroup");
+        user.setGroups(groups);
+
+        assertFalse(filter.matches(user));
+    }
+
+}

--- a/src/test/java/edu/wisc/my/messages/model/AudienceFilterTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/AudienceFilterTest.java
@@ -21,7 +21,7 @@ public class AudienceFilterTest {
         groups.add("unrelatedGroup");
         user.setGroups(groups);
 
-        assertTrue(filter.matches(user));
+        assertTrue(filter.test(user));
     }
 
     @Test
@@ -36,7 +36,7 @@ public class AudienceFilterTest {
         groups.add("unrelatedGroup");
         user.setGroups(groups);
 
-        assertFalse(filter.matches(user));
+        assertFalse(filter.test(user));
     }
 
 }

--- a/src/test/java/edu/wisc/my/messages/model/MessageArrayTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/MessageArrayTest.java
@@ -1,0 +1,28 @@
+package edu.wisc.my.messages.model;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class MessageArrayTest {
+    @Test
+    public void createMessageArrayFromList() {
+
+        List<Message> someMessages = new ArrayList<>();
+
+        Message aMessage = new Message();
+        Message anotherMessage = new Message();
+        Message yetAnotherMessage = new Message();
+
+        someMessages.add(aMessage);
+        someMessages.add(anotherMessage);
+        someMessages.add(yetAnotherMessage);
+
+        MessageArray messageArray = new MessageArray(someMessages);
+
+        assertArrayEquals(someMessages.toArray(), messageArray.getMessages());
+    }
+}

--- a/src/test/java/edu/wisc/my/messages/model/UserTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/UserTest.java
@@ -1,0 +1,15 @@
+package edu.wisc.my.messages.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class UserTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void cannotSetGroupsToNull() {
+        User user = new User();
+        user.setGroups(null);
+    }
+
+}

--- a/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
+++ b/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
@@ -67,13 +67,13 @@ public class MessagesServiceTest {
         MessagesService service = new MessagesService();
 
         AudienceFilter yesFilter = mock(AudienceFilter.class);
-        when(yesFilter.matches(any())).thenReturn(true);
+        when(yesFilter.test(any())).thenReturn(true);
         Message matchingMessage = new Message();
         matchingMessage.setAudienceFilter(yesFilter);
         matchingMessage.setId("uniqueMessageId");
 
         AudienceFilter noFilter = mock(AudienceFilter.class);
-        when(noFilter.matches(any())).thenReturn(false);
+        when(noFilter.test(any())).thenReturn(false);
         Message unmatchingMessage = new Message();
         unmatchingMessage.setAudienceFilter(noFilter);
 

--- a/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
+++ b/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
@@ -1,0 +1,106 @@
+package edu.wisc.my.messages.service;
+
+import edu.wisc.my.messages.data.MessagesFromTextFile;
+import edu.wisc.my.messages.model.AudienceFilter;
+import edu.wisc.my.messages.model.Message;
+// import edu.wisc.my.messages.model.User;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+import static org.mockito.Mockito.*;
+
+public class MessagesServiceTest {
+
+
+    /**
+     * Test that passes along all messages from repository.
+     */
+    @Test
+    public void handsAlongAllMessagesFromRepository() {
+        MessagesService service = new MessagesService();
+
+        Message firstMessage = new Message();
+        firstMessage.setId("uniqueMessageId-1");
+
+        Message secondMessage = new Message();
+        secondMessage.setId("anotherMessageId-2");
+
+        List<Message> messagesFromRepository = new ArrayList<>();
+        messagesFromRepository.add(firstMessage);
+        messagesFromRepository.add(secondMessage);
+
+        MessagesFromTextFile messageSource = mock(MessagesFromTextFile.class);
+        when(messageSource.allMessages()).thenReturn(messagesFromRepository);
+
+        service.setMessageSource(messageSource);
+
+        JSONObject result = service.allMessages();
+
+        // result should be a message array containing both messages
+
+        assertNotNull(result);
+
+        JSONArray resultMessages = result.getJSONArray("messages");
+        assertNotNull(resultMessages);
+        assertEquals(2, resultMessages.length());
+
+        JSONObject firstResultMessage = resultMessages.getJSONObject(0);
+        assertEquals("uniqueMessageId-1", firstResultMessage.getString("id"));
+
+        JSONObject secondResultMessage = resultMessages.getJSONObject(1);
+        assertEquals("anotherMessageId-2", secondResultMessage.getString("id"));
+    }
+
+
+    /**
+     * Test that filters away messages with AudienceFilters reporting no match.
+     */
+    @Test
+    @Ignore
+    public void includesOnlyMessagesMatchingAudienceFilters() {
+        MessagesService service = new MessagesService();
+
+        AudienceFilter yesFilter = mock(AudienceFilter.class);
+        when(yesFilter.matches(any())).thenReturn(true);
+        Message matchingMessage = new Message();
+        matchingMessage.setAudienceFilter(yesFilter);
+        matchingMessage.setId("uniqueMessageId");
+
+        AudienceFilter noFilter = mock(AudienceFilter.class);
+        when(noFilter.matches(any())).thenReturn(false);
+        Message unmatchingMessage = new Message();
+        unmatchingMessage.setAudienceFilter(noFilter);
+
+        List<Message> unfilteredMessages = new ArrayList<>();
+        unfilteredMessages.add(matchingMessage);
+        unfilteredMessages.add(unmatchingMessage);
+
+        MessagesFromTextFile messageSource = mock(MessagesFromTextFile.class);
+        when(messageSource.allMessages()).thenReturn(unfilteredMessages);
+
+        service.setMessageSource(messageSource);
+
+        //User user = new User();
+
+        JSONObject result = null; //service.filteredMessages(user);
+
+        assertNotNull(result);
+
+        JSONArray resultMessages = result.getJSONArray("messages");
+        assertNotNull(resultMessages);
+
+        assertEquals(1, resultMessages.length());
+
+        JSONObject resultMessage = resultMessages.getJSONObject(0);
+
+        assertEquals("uniqueMessageId", resultMessage.getString("id"));
+    }
+
+}

--- a/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
+++ b/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
@@ -3,7 +3,7 @@ package edu.wisc.my.messages.service;
 import edu.wisc.my.messages.data.MessagesFromTextFile;
 import edu.wisc.my.messages.model.AudienceFilter;
 import edu.wisc.my.messages.model.Message;
-// import edu.wisc.my.messages.model.User;
+import edu.wisc.my.messages.model.User;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Ignore;
@@ -63,7 +63,6 @@ public class MessagesServiceTest {
      * Test that filters away messages with AudienceFilters reporting no match.
      */
     @Test
-    @Ignore
     public void includesOnlyMessagesMatchingAudienceFilters() {
         MessagesService service = new MessagesService();
 
@@ -87,9 +86,9 @@ public class MessagesServiceTest {
 
         service.setMessageSource(messageSource);
 
-        //User user = new User();
+        User user = new User();
 
-        JSONObject result = null; //service.filteredMessages(user);
+        JSONObject result = service.filteredMessages(user);
 
         assertNotNull(result);
 


### PR DESCRIPTION
Filters messages to those matching the requesting user's groups.

**Problem with this solution**:
+ This changeset implements group filtering based on `isMemberOf` header. This will work *great* for groups available from UW-Madison's IdP, that is, "Manifest" groups. This won't work at all for other groups (e.g. uPortal PaGS groups) and other IdPs (hi, UW-System!) that don't set this header. We'll need to either rationalize how we present groups to microservices (get other campuses to set isMemberOf, virtually set that from other sources, something?) or implement another way of getting groups (uPortal groups API? How?)

Changes:
+ `/messages` is now the filtered-to-user path (had been `/currentMessages`, which is no more).
+ `/allMessages` is now the all-the-messages path (had been `/messages`).

Features:

+ filters messages so they are only seen by users who are members of at least one group in the message's audience, in cases where messages have an audience filter specifying groups.
+ Adds rudimentary User model, parsing user groups from `isMemberOf` header.
+ `AudienceFilter`s are now able to apply themselves to `User`s to answer whether they "match" that user (whether the user is in the audience), as `Predicate<User` no less.

Refactors:

+ Introduces Repository layer to architecture, moving text file reading and parsing out of the Service and into this new Repository layer.

Tradeoffs navigated:

+ Identity and authorization needed is currently very simple, such that arguably it's okay to introduce an ad-hoc `User` to the model, determined from the Request in the Controller layer, passed on to the Service layer, etc. Alternatively could be using something more elegant, e.g. Spring Security or Shiro.
+ I didn't understand the existing `MessagesControllerTest` or how to add to it the kind of Mockito mocked unit tests I know how to write generally for Java regardless of all this Spring stuff. So I introduced a `MessagesControllerUnitTest` to house no-magic-MVC-context vanilla `JUnit`/`Mockito` tests for that controller. Upshot is reasonable confidence this changeset doesn't break things (through test scaffolding) but not rationalizing how unit tests are implemented for this controller.
+ Refactoring to make the service layer speak domain objects rather than JSON is probably a good idea, but this changeset doesn't do it.

----

[Definition of Done][]

<!-- Intended as a low-intrusion quick checklist reminder of Definition of Done.
     Routinely, take the opportunity to reflect and then tick off the did-the-right-thing-for items.
     Exceptionally, explain what's exceptional why.
-->

Exceptions to Definition of Done:
+ security: NOT implementing access control, punting that to container layer.
+ configurability: NOT making microservice configurable as to what filtering it's doing. It's configurable within the domain model in that `AudienceFilter`s are optional for messages: no filter, no filtering by group.
+ configurability: NOT making name and nature of header specifying group memberships configurable, since arguably we only need `isMemberOf`.
+ security and validation: NOT implementing extra validation/sanitization on `isMemberOf` header. Hypothetically a do-badder could implement a DoS attack by feeding the microservice an arbitrarily huge `isMemberOf` header value which would be expensive to parse. To the extent that `isMemberOf` header size should be limited, that limiting should happen at container/`httpd` layer and doesn't need to be here.

- [x] Documented (README updated, JavaDoc added).
- [x] Fails gracefully (handles missing `isMemberOf`, handles no `AudienceFilter`).
- [x] Tested (Covered by unit tests, manually tested as running Boot service).
- [x] Secure (**Exception**).
- [x] Adds no defects (At least none that the automated tests detect.)
- [x] Shippable. Path is clear to promote to production. (We're in `0.1.0` status. This changeset makes the product no less releasable.)
- [x] Maintainable
- [x] Configurable (**Exception**.)
- [x] Readable
- [x] Validates and sanitizes user input (**Exception**.)
- [x] Styled (No style is defined for this repo.)

[Definition of Done]: https://goo.gl/4JG2Z5