### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+continuation_indent_size = 2
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
Google Style, insofar as `.editorconfig` can model it,
naively (in the sense of no attempt to differentiate Java from other files.)

Resolves #29 .

----

[Definition of Done][]

<!-- Intended as a low-intrusion quick checklist reminder of Definition of Done.
     Routinely, take the opportunity to reflect and then tick off the did-the-right-thing-for items.
     Exceptionally, explain what's exceptional why.
-->

Exception: defects: *Not* touching all the files to adopt the whitespace prescribed by this `.editorconfig` in this changeset, figuring that would needlessly introduce a bunch of merge conflicts with in-flight changes. Rather intend to offer that changeset after in-flight changes merge. This means that temporarily this changeset introduces the defect of existing code out-of-norm with prescribed whitespace.)

- [x] Documented (figure `.editorconfig` is self-documenting).
- [x] Fails gracefully (there's nothing to fail).
- [x] Tested (copy-and-paste from `uPortal-home`, so it's in practice tested there).
- [x] Secure (no security implications)
- [x] Adds no defects (**Exception**),
- [x] Shippable. Path is clear to promote to production
- [x] Maintainable
- [x] Configurable
- [x] Readable
- [x] Validates and sanitizes user input (no user input)
- [x] Styled

[Definition of Done]: https://goo.gl/4JG2Z5