### PR TITLE
fix: drop validToday from JSON

### DIFF
--- a/src/main/java/edu/wisc/my/messages/model/Message.java
+++ b/src/main/java/edu/wisc/my/messages/model/Message.java
@@ -3,6 +3,8 @@ package edu.wisc.my.messages.model;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang.StringUtils;
 import javax.validation.constraints.NotNull;
 
@@ -311,7 +313,8 @@ public class Message   {
   public void setConfirmButton(ActionButton confirmButton) {
     this.confirmButton = confirmButton;
   }
-  
+
+  @JsonIgnore
   public boolean isValidToday(){
 
    Date today = new Date();


### PR DESCRIPTION
Not clear that this was intentionally included in the JSON. Maybe it should be. But let's add it when we need it in the JSON consumer.

----

[Definition of Done][]

<!-- Intended as a low-intrusion quick checklist reminder of Definition of Done.
     Routinely, take the opportunity to reflect and then tick off the did-the-right-thing-for items.
     Exceptionally, explain what's exceptional why.
-->

- [x] Documented (self-documenting; `validToday` was not a documented part of JSON expectations)
- [x] Fails gracefully
- [x] Tested (manually)
- [x] Secure
- [x] Adds no defects
- [x] Shippable. Path is clear to promote to production
- [x] Maintainable
- [x] Configurable (Nothing to configure)
- [x] Readable
- [x] Validates and sanitizes user input (no user input)
- [x] Styled (no style defined)

[Definition of Done]: https://goo.gl/4JG2Z5