### PR TITLE
feat: support ISO THH:MM:SS date-time suffixes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,8 @@ resolution server-side into this microservice so that a typical client can reque
 
 Currently filters to:
 
-+ Applicable to the current date. (Messages can have not-before and not-after dates.), AND
++ Applicable to the current local date-time. (Messages can have not-before and not-after date-times,
+specified in ISO format, as in `2018-02-14` or `2018-02-14:09:46:00`), AND
 + Applicable to the user's groups. (Messages can be limited to user groups.)
 
 Expectations:

--- a/src/main/java/edu/Application.java
+++ b/src/main/java/edu/Application.java
@@ -1,12 +1,7 @@
 package edu;
 
-import java.util.Arrays;
-
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.Bean;
 import org.springframework.boot.web.support.SpringBootServletInitializer;
 
 @SpringBootApplication

--- a/src/main/java/edu/wisc/my/messages/controller/IsMemberOfHeaderParser.java
+++ b/src/main/java/edu/wisc/my/messages/controller/IsMemberOfHeaderParser.java
@@ -1,12 +1,10 @@
 package edu.wisc.my.messages.controller;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.stereotype.Component;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import org.springframework.stereotype.Component;
 
 /**
  * Utility for parsing isMemberOf header.

--- a/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
+++ b/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
@@ -1,9 +1,10 @@
 package edu.wisc.my.messages.controller;
 
+import edu.wisc.my.messages.model.User;
+import edu.wisc.my.messages.service.MessagesService;
+import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import edu.wisc.my.messages.model.User;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,12 +13,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
-
-import edu.wisc.my.messages.service.MessagesService;
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Understands what HTTP requests are asking about messages, queries the MessagesService

--- a/src/main/java/edu/wisc/my/messages/data/MessagesFromTextFile.java
+++ b/src/main/java/edu/wisc/my/messages/data/MessagesFromTextFile.java
@@ -3,6 +3,10 @@ package edu.wisc.my.messages.data;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.wisc.my.messages.model.Message;
 import edu.wisc.my.messages.model.MessageArray;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.commons.io.IOUtils;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,11 +14,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Repository;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.List;
 
 @Repository
 public class MessagesFromTextFile {

--- a/src/main/java/edu/wisc/my/messages/model/ActionButton.java
+++ b/src/main/java/edu/wisc/my/messages/model/ActionButton.java
@@ -1,11 +1,7 @@
 package edu.wisc.my.messages.model;
 
-import java.util.Objects;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-
-import javax.validation.constraints.*;
+import java.util.Objects;
 
 /**
  * ActionButton

--- a/src/main/java/edu/wisc/my/messages/model/AudienceFilter.java
+++ b/src/main/java/edu/wisc/my/messages/model/AudienceFilter.java
@@ -1,12 +1,12 @@
 package edu.wisc.my.messages.model;
 
-import java.util.*;
-import java.util.function.Predicate;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-
-import javax.validation.constraints.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Predicate over User, answering whether the User is or is not in the Audience. <p> Currently

--- a/src/main/java/edu/wisc/my/messages/model/Data.java
+++ b/src/main/java/edu/wisc/my/messages/model/Data.java
@@ -1,11 +1,7 @@
 package edu.wisc.my.messages.model;
 
-import java.util.Objects;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-
-import javax.validation.constraints.*;
+import java.util.Objects;
 
 /**
  * Data

--- a/src/main/java/edu/wisc/my/messages/model/Message.java
+++ b/src/main/java/edu/wisc/my/messages/model/Message.java
@@ -1,5 +1,6 @@
 package edu.wisc.my.messages.model;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
@@ -322,14 +323,29 @@ public class Message {
 
     try {
       // if the message is premature, it is not valid.
-      if (StringUtils.isNotBlank(goLiveDate) && LocalDateTime.parse(goLiveDate).isAfter(now)) {
+      // go live date might be time specified
+      if (StringUtils.isNotBlank(goLiveDate) && goLiveDate.contains("T")
+        && LocalDateTime.parse(goLiveDate).isAfter(now)) {
+        return false;
+      }
+      // or go live date might not be time specified
+      if (StringUtils.isNotBlank(goLiveDate) && !goLiveDate.contains("T")
+        && LocalDate.parse(goLiveDate).isAfter(now.toLocalDate())) {
         return false;
       }
 
       // if the message is expired, it is not valid
-      if (StringUtils.isNotBlank(expireDate) && LocalDateTime.parse(expireDate).isBefore(now)) {
+      // expiration date might be time specified
+      if (StringUtils.isNotBlank(expireDate) && expireDate.contains("T")
+        && LocalDateTime.parse(expireDate).isBefore(now)) {
         return false;
       }
+      // or expiration date might not be time specified
+      if (StringUtils.isNotBlank(expireDate) && !expireDate.contains("T")
+        && LocalDate.parse(expireDate).isBefore(now.toLocalDate())) {
+        return false;
+      }
+
 
       // if the message is neither premature nor expired, it's valid
       return true;

--- a/src/main/java/edu/wisc/my/messages/model/Message.java
+++ b/src/main/java/edu/wisc/my/messages/model/Message.java
@@ -1,20 +1,13 @@
 package edu.wisc.my.messages.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.wisc.my.messages.service.ExpiredMessagePredicate;
 import edu.wisc.my.messages.service.GoneLiveMessagePredicate;
-import edu.wisc.my.messages.time.IsoDateTimeStringAfterPredicate;
-import edu.wisc.my.messages.time.IsoDateTimeStringBeforePredicate;
-
 import java.time.LocalDateTime;
 import java.util.Objects;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import java.util.function.Predicate;
 import javax.validation.constraints.NotNull;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/edu/wisc/my/messages/model/Message.java
+++ b/src/main/java/edu/wisc/my/messages/model/Message.java
@@ -1,6 +1,8 @@
 package edu.wisc.my.messages.model;
 
-import java.time.LocalDate;
+import edu.wisc.my.messages.time.IsoDateTimeStringAfterPredicate;
+import edu.wisc.my.messages.time.IsoDateTimeStringBeforePredicate;
+
 import java.time.LocalDateTime;
 import java.util.Objects;
 
@@ -10,7 +12,6 @@ import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -319,33 +320,23 @@ public class Message {
 
   @JsonIgnore
   public boolean isValidToday() {
-    LocalDateTime now = LocalDateTime.now();
+
+    IsoDateTimeStringBeforePredicate beforeNow =
+      new IsoDateTimeStringBeforePredicate(LocalDateTime.now());
+
+    IsoDateTimeStringAfterPredicate afterNow =
+      new IsoDateTimeStringAfterPredicate(LocalDateTime.now());
 
     try {
       // if the message is premature, it is not valid.
-      // go live date might be time specified
-      if (StringUtils.isNotBlank(goLiveDate) && goLiveDate.contains("T")
-        && LocalDateTime.parse(goLiveDate).isAfter(now)) {
-        return false;
-      }
-      // or go live date might not be time specified
-      if (StringUtils.isNotBlank(goLiveDate) && !goLiveDate.contains("T")
-        && LocalDate.parse(goLiveDate).isAfter(now.toLocalDate())) {
+      if (afterNow.test(goLiveDate)) {
         return false;
       }
 
       // if the message is expired, it is not valid
-      // expiration date might be time specified
-      if (StringUtils.isNotBlank(expireDate) && expireDate.contains("T")
-        && LocalDateTime.parse(expireDate).isBefore(now)) {
+      if (beforeNow.test(expireDate)) {
         return false;
       }
-      // or expiration date might not be time specified
-      if (StringUtils.isNotBlank(expireDate) && !expireDate.contains("T")
-        && LocalDate.parse(expireDate).isBefore(now.toLocalDate())) {
-        return false;
-      }
-
 
       // if the message is neither premature nor expired, it's valid
       return true;

--- a/src/main/java/edu/wisc/my/messages/model/Message.java
+++ b/src/main/java/edu/wisc/my/messages/model/Message.java
@@ -9,6 +9,7 @@ import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -321,12 +322,12 @@ public class Message {
 
     try {
       // if the message is premature, it is not valid.
-      if (null != goLiveDate && LocalDateTime.parse(goLiveDate).isAfter(now)) {
+      if (StringUtils.isNotBlank(goLiveDate) && LocalDateTime.parse(goLiveDate).isAfter(now)) {
         return false;
       }
 
       // if the message is expired, it is not valid
-      if (null != expireDate && LocalDateTime.parse(expireDate).isBefore(now)) {
+      if (StringUtils.isNotBlank(expireDate) && LocalDateTime.parse(expireDate).isBefore(now)) {
         return false;
       }
 

--- a/src/main/java/edu/wisc/my/messages/model/User.java
+++ b/src/main/java/edu/wisc/my/messages/model/User.java
@@ -1,9 +1,8 @@
 package edu.wisc.my.messages.model;
 
-import org.apache.commons.lang.Validate;
-
 import java.util.HashSet;
 import java.util.Set;
+import org.apache.commons.lang.Validate;
 
 public class User {
 

--- a/src/main/java/edu/wisc/my/messages/model/User.java
+++ b/src/main/java/edu/wisc/my/messages/model/User.java
@@ -7,6 +7,11 @@ import org.apache.commons.lang.Validate;
 public class User {
 
   /**
+   * The groups of which the user is a member.
+   */
+  private Set<String> groups = new HashSet<>();
+
+  /**
    * Get the groups of which the user is a member.
    *
    * @return potentially empty Set
@@ -24,10 +29,5 @@ public class User {
     Validate.notNull(groups);
     this.groups = groups;
   }
-
-  /**
-   * The groups of which the user is a member.
-   */
-  private Set<String> groups = new HashSet<>();
 
 }

--- a/src/main/java/edu/wisc/my/messages/service/AudienceFilterMessagePredicate.java
+++ b/src/main/java/edu/wisc/my/messages/service/AudienceFilterMessagePredicate.java
@@ -1,0 +1,34 @@
+package edu.wisc.my.messages.service;
+
+import edu.wisc.my.messages.model.AudienceFilter;
+import edu.wisc.my.messages.model.Message;
+import edu.wisc.my.messages.model.User;
+import java.util.function.Predicate;
+import org.apache.commons.lang.Validate;
+
+/**
+ * Predicate that is true for messages where all of the potentially none audience filters of which
+ * return true for the user specified in the constructor, and false otherwise.
+ */
+public class AudienceFilterMessagePredicate
+  implements Predicate<Message> {
+
+  private final User user;
+
+  public AudienceFilterMessagePredicate(User user) {
+    this.user = user;
+  }
+
+  @Override
+  public boolean test(Message message) {
+    Validate.notNull(message);
+
+    AudienceFilter audienceFilter = message.getAudienceFilter();
+
+    if (null == audienceFilter) {
+      return true; // all of the zero audience filters passed
+    }
+
+    return audienceFilter.test(user);
+  }
+}

--- a/src/main/java/edu/wisc/my/messages/service/ExpiredMessagePredicate.java
+++ b/src/main/java/edu/wisc/my/messages/service/ExpiredMessagePredicate.java
@@ -1,0 +1,36 @@
+package edu.wisc.my.messages.service;
+
+import edu.wisc.my.messages.model.Message;
+import edu.wisc.my.messages.time.IsoDateTimeStringBeforePredicate;
+import java.time.LocalDateTime;
+import java.util.function.Predicate;
+import org.apache.commons.lang.Validate;
+
+/**
+ * Predicate that is true for messages that are expired (or cannot be verified as not expired due to
+ * bogus expiration data.) False otherwise. Throws RuntimeException on evaluating null message.
+ */
+public class ExpiredMessagePredicate
+  implements Predicate<Message> {
+
+  private LocalDateTime when;
+
+  public ExpiredMessagePredicate(LocalDateTime asOfWhen) {
+    this.when = asOfWhen;
+  }
+
+  @Override
+  public boolean test(Message message) {
+    Validate.notNull(message);
+
+    IsoDateTimeStringBeforePredicate beforeWhen =
+      new IsoDateTimeStringBeforePredicate(when);
+
+    try {
+      return beforeWhen.test(message.getExpireDate());
+    } catch (Exception e) {
+      return true;
+    }
+
+  }
+}

--- a/src/main/java/edu/wisc/my/messages/service/GoneLiveMessagePredicate.java
+++ b/src/main/java/edu/wisc/my/messages/service/GoneLiveMessagePredicate.java
@@ -1,0 +1,37 @@
+package edu.wisc.my.messages.service;
+
+import edu.wisc.my.messages.model.Message;
+import edu.wisc.my.messages.time.IsoDateTimeStringAfterPredicate;
+import java.time.LocalDateTime;
+import java.util.function.Predicate;
+import org.apache.commons.lang.Validate;
+
+/**
+ * Predicate that is true for messages that have gone live, either because they have no goLiveDate
+ * or because their goLiveDate is before the date of comparison as given in the constructor.
+ * Messages with unparseable go live dates have not gone live.
+ */
+public class GoneLiveMessagePredicate
+  implements Predicate<Message> {
+
+  LocalDateTime when;
+
+  public GoneLiveMessagePredicate(LocalDateTime asOfWhen) {
+    this.when = asOfWhen;
+  }
+
+
+  @Override
+  public boolean test(Message message) {
+    Validate.notNull(message);
+
+    IsoDateTimeStringAfterPredicate afterWhen = new IsoDateTimeStringAfterPredicate(when);
+
+    try {
+      return (!afterWhen.test(message.getGoLiveDate()));
+    } catch (Exception e) {
+      return false;
+    }
+
+  }
+}

--- a/src/main/java/edu/wisc/my/messages/service/MessagesService.java
+++ b/src/main/java/edu/wisc/my/messages/service/MessagesService.java
@@ -55,6 +55,9 @@ public class MessagesService {
       new ExpiredMessagePredicate(LocalDateTime.now()).negate()
         .and(new GoneLiveMessagePredicate(LocalDateTime.now()));
 
+    Predicate<Message> retainMessage =
+      neitherPrematureNorExpired.and(new AudienceFilterMessagePredicate(user));
+
     JSONObject validMessages = new JSONObject();
     JSONArray validMessageArray = new JSONArray();
     ObjectMapper mapper = new ObjectMapper();
@@ -65,9 +68,7 @@ public class MessagesService {
 
     try {
       for (Message message : messageSource.allMessages()) {
-        if (neitherPrematureNorExpired.test(message)
-          && ((null == message.getAudienceFilter() || message.getAudienceFilter().test(user)))
-          ) {
+        if (retainMessage.test(message)) {
           JSONObject validMessage = new JSONObject(message);
           validMessageArray.put(validMessage);
         }

--- a/src/main/java/edu/wisc/my/messages/service/MessagesService.java
+++ b/src/main/java/edu/wisc/my/messages/service/MessagesService.java
@@ -1,28 +1,19 @@
 package edu.wisc.my.messages.service;
 
-import java.io.InputStream;
-import java.time.LocalDateTime;
-import java.util.List;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import com.fasterxml.jackson.databind.SerializationFeature;
 import edu.wisc.my.messages.data.MessagesFromTextFile;
+import edu.wisc.my.messages.model.Message;
 import edu.wisc.my.messages.model.User;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.function.Predicate;
-import org.apache.commons.io.IOUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Service;
-
-import edu.wisc.my.messages.model.Message;
-import edu.wisc.my.messages.model.MessageArray;
 
 @Service
 public class MessagesService {

--- a/src/main/java/edu/wisc/my/messages/time/IsoDateTimeStringAfterPredicate.java
+++ b/src/main/java/edu/wisc/my/messages/time/IsoDateTimeStringAfterPredicate.java
@@ -1,0 +1,35 @@
+package edu.wisc.my.messages.time;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.function.Predicate;
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Predicate that is true for Strings that represent dates and date-times that are after the
+ * LocalDateTime given at construction. False for null, empty, and blank inputs. Throws
+ * RuntimeException on otherwise unparseable input.
+ */
+public class IsoDateTimeStringAfterPredicate
+  implements Predicate<String> {
+
+  LocalDateTime when;
+
+  public IsoDateTimeStringAfterPredicate(LocalDateTime afterWhen) {
+    this.when = afterWhen;
+  }
+
+  @Override
+  public boolean test(String s) {
+
+    if (StringUtils.isBlank(s)) {
+      return false;
+    }
+
+    if (s.contains("T")) {
+      return LocalDateTime.parse(s).isAfter(when);
+    } else {
+      return LocalDate.parse(s).isAfter(when.toLocalDate());
+    }
+  }
+}

--- a/src/main/java/edu/wisc/my/messages/time/IsoDateTimeStringBeforePredicate.java
+++ b/src/main/java/edu/wisc/my/messages/time/IsoDateTimeStringBeforePredicate.java
@@ -1,6 +1,5 @@
 package edu.wisc.my.messages.time;
 
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.function.Predicate;

--- a/src/main/java/edu/wisc/my/messages/time/IsoDateTimeStringBeforePredicate.java
+++ b/src/main/java/edu/wisc/my/messages/time/IsoDateTimeStringBeforePredicate.java
@@ -1,0 +1,37 @@
+package edu.wisc.my.messages.time;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.function.Predicate;
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Predicate that is true if the String represents a date or date-time in ISO format that is before
+ * the LocalDateTime specified at construction. False otherwise, including on null, empty, or blank
+ * input. Throws RuntimeException on non-blank unparseable input.
+ */
+public class IsoDateTimeStringBeforePredicate
+  implements Predicate<String> {
+
+  LocalDateTime when;
+
+  public IsoDateTimeStringBeforePredicate(LocalDateTime beforeWhen) {
+    this.when = beforeWhen;
+  }
+
+  @Override
+  public boolean test(String s) {
+    if (StringUtils.isBlank(s)) {
+      return false;
+    }
+
+    // the date string might be time-specified
+    if (s.contains("T")) {
+      return LocalDateTime.parse(s).isBefore(when);
+    } else {
+      return LocalDate.parse(s).isBefore(when.toLocalDate());
+    }
+  }
+
+}

--- a/src/test/java/edu/wisc/my/messages/controller/IsMemberOfHeaderParserTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/IsMemberOfHeaderParserTest.java
@@ -1,12 +1,11 @@
 package edu.wisc.my.messages.controller;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-
-import static org.junit.Assert.*;
+import org.junit.Test;
 
 public class IsMemberOfHeaderParserTest {
 

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerIT.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerIT.java
@@ -1,10 +1,9 @@
 package edu.wisc.my.messages.controller;
 
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import java.net.URL;
-
+import org.hamcrest.core.StringContains;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,7 +13,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.hamcrest.core.StringContains;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
@@ -1,9 +1,9 @@
 package edu.wisc.my.messages.controller;
 
-import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.hamcrest.core.StringContains;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +13,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.hamcrest.core.StringContains;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
@@ -1,19 +1,21 @@
 package edu.wisc.my.messages.controller;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import edu.wisc.my.messages.model.User;
 import edu.wisc.my.messages.service.MessagesService;
+import java.util.HashSet;
+import java.util.Set;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import java.util.HashSet;
-import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
 
 public class MessagesControllerUnitTest {
 

--- a/src/test/java/edu/wisc/my/messages/model/AudienceFilterTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/AudienceFilterTest.java
@@ -1,11 +1,11 @@
 package edu.wisc.my.messages.model;
 
-import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashSet;
 import java.util.Set;
-
-import static org.junit.Assert.*;
+import org.junit.Test;
 
 public class AudienceFilterTest {
 

--- a/src/test/java/edu/wisc/my/messages/model/MessageArrayTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/MessageArrayTest.java
@@ -1,11 +1,10 @@
 package edu.wisc.my.messages.model;
 
-import org.junit.Test;
+import static org.junit.Assert.assertArrayEquals;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.junit.Assert.*;
+import org.junit.Test;
 
 public class MessageArrayTest {
 

--- a/src/test/java/edu/wisc/my/messages/model/UserTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/UserTest.java
@@ -2,8 +2,6 @@ package edu.wisc.my.messages.model;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-
 public class UserTest {
 
   @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
@@ -74,4 +74,34 @@ public class ValidDateTest {
     assertTrue("Should not be expired because two seconds from now is not expired.",
       message.isValidToday());
   }
+
+  @Test
+  public void goingLiveLaterTodayIsNotLive() throws InterruptedException {
+
+    // assumption: this test will not take more than 2 seconds.
+
+    // this test relies on two seconds from now being in the same date, so that an implementation
+    // that respects time will notice that the that timestamp is not yet expired whereas an
+    // implementation that only respects dates will consider that timestamp expired.
+    //
+    // therefore edge case: it is less than four seconds before the date rolls over
+    // in this case wait four seconds to escape the edge case
+
+    LocalDateTime now = LocalDateTime.now();
+
+    if (now.getHour() == 23 && now.getSecond() > 56) {
+      wait(4000);
+    }
+
+    // two seconds from now is within the current date, either because not in the edge case
+    // or because waited for the edge case to pass
+
+    LocalDateTime twoSecondsLaterThanNow = LocalDateTime.now().plusSeconds(2);
+
+    Message message = new Message();
+    message.setGoLiveDate(twoSecondsLaterThanNow.toString());
+    assertFalse("Should not be valid because two seconds from now is not gone live.",
+      message.isValidToday());
+
+  }
 }

--- a/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
@@ -10,15 +10,6 @@ import org.junit.Test;
 public class ValidDateTest {
 
   @Test
-  public void futureExpiredDatesCanOmitTime() {
-    Message message = new Message();
-    String longFutureDate = "2999-12-31";
-    message.setExpireDate(longFutureDate);
-    assertTrue("Future expiration date omitting time should not invalidate message",
-      message.isValidToday());
-  }
-
-  @Test
   public void filterOutNotYetLiveDates() {
     Message message = new Message();
     String futureDate = "2100-12-31";

--- a/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
@@ -3,6 +3,7 @@ package edu.wisc.my.messages.model;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.time.LocalDateTime;
 import org.junit.Test;
 
 
@@ -40,4 +41,37 @@ public class ValidDateTest {
         assertTrue(message.isValidToday());
     }
 
+  /**
+   * Test that messages that expire later today are not considered expired.
+   * That is, that expiration supports the THH:MM suffix on ISO date-times.
+   */
+  @Test
+  public void expiringLaterTodayIsNotExpired() throws InterruptedException {
+
+    // assumption: this test will not take more than 2 seconds.
+
+    // this test relies on two seconds from now being in the same date, so that an implementation
+    // that respects time will notice that the that timestamp is not yet expired whereas an
+    // implementation that only respects dates will consider that timestamp expired.
+    //
+    // therefore edge case: it is less than four seconds before the date rolls over
+    // in this case wait four seconds to escape the edge case
+
+    LocalDateTime now = LocalDateTime.now();
+
+    if (now.getHour() == 23 && now.getSecond() > 56) {
+      wait(4000);
+    }
+
+    // two seconds from now is within the current date, either because not in the edge case
+    // or because waited for the edge case to pass
+
+    LocalDateTime twoSecondsLaterThanNow = LocalDateTime.now().plusSeconds(2);
+
+    Message message = new Message();
+    message.setExpireDate(twoSecondsLaterThanNow.toString());
+    message.setGoLiveDate("1900-01-01T03:00");
+    assertTrue("Should not be expired because two seconds from now is not expired.",
+      message.isValidToday());
+  }
 }

--- a/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
@@ -8,87 +8,87 @@ import org.junit.Test;
 
 
 public class ValidDateTest {
-    
-    @Test
-    public void filterOutExpiredDates() {
-        Message message = new Message();
-        String longAgoDate = "1999-12-31";
-        message.setExpireDate(longAgoDate);
-        assertFalse("Expired messages should not be valid.",
-          message.isValidToday());
-    }
 
-    @Test
-    public void expiredDatesCanBeSpecifiedWithTime() {
-      Message message = new Message();
-      String longAgoDateTime = "1999-12-31T13:21:14";
-      message.setExpireDate(longAgoDateTime);
-      assertFalse("Time-specified expire date-times should be honored.",
-        message.isValidToday());
-    }
+  @Test
+  public void filterOutExpiredDates() {
+    Message message = new Message();
+    String longAgoDate = "1999-12-31";
+    message.setExpireDate(longAgoDate);
+    assertFalse("Expired messages should not be valid.",
+      message.isValidToday());
+  }
 
-    @Test
-    public void futureExpiredDatesCanOmitTime() {
-      Message message = new Message();
-      String longFutureDate = "2999-12-31";
-      message.setExpireDate(longFutureDate);
-      assertTrue("Future expiration date omitting time should not invalidate message",
-        message.isValidToday());
-    }
+  @Test
+  public void expiredDatesCanBeSpecifiedWithTime() {
+    Message message = new Message();
+    String longAgoDateTime = "1999-12-31T13:21:14";
+    message.setExpireDate(longAgoDateTime);
+    assertFalse("Time-specified expire date-times should be honored.",
+      message.isValidToday());
+  }
 
-    @Test
-    public void filterOutNotYetLiveDates() {
-        Message message = new Message();
-        String futureDate = "2100-12-31";
-        message.setGoLiveDate(futureDate);
-        assertFalse("Future go-live date without tim specified should invalidate message.",
-          message.isValidToday());
-    }
+  @Test
+  public void futureExpiredDatesCanOmitTime() {
+    Message message = new Message();
+    String longFutureDate = "2999-12-31";
+    message.setExpireDate(longFutureDate);
+    assertTrue("Future expiration date omitting time should not invalidate message",
+      message.isValidToday());
+  }
 
-    @Test
-    public void pastGoLiveDatesYieldValidMessages() {
-      Message message = new Message();
-      String pastDate = "2000-04-12T12:21:21";
-      message.setGoLiveDate(pastDate);
-      assertTrue("Messages with past go-live date-times with time specified should be valid.",
-        message.isValidToday());
-    }
+  @Test
+  public void filterOutNotYetLiveDates() {
+    Message message = new Message();
+    String futureDate = "2100-12-31";
+    message.setGoLiveDate(futureDate);
+    assertFalse("Future go-live date without tim specified should invalidate message.",
+      message.isValidToday());
+  }
 
-    @Test
-    public void pastGoLiveDatesCanOmitTime() {
-      Message message = new Message();
-      String pastDate = "2000-04-12";
-      message.setGoLiveDate(pastDate);
-      assertTrue("Past go-live date omitting time should not invalidate message.",
-        message.isValidToday());
-    }
+  @Test
+  public void pastGoLiveDatesYieldValidMessages() {
+    Message message = new Message();
+    String pastDate = "2000-04-12T12:21:21";
+    message.setGoLiveDate(pastDate);
+    assertTrue("Messages with past go-live date-times with time specified should be valid.",
+      message.isValidToday());
+  }
 
-    @Test
-    public void filterOutImproperDates() {
-        Message message = new Message();
-        String nonsenseDate = "Not a date";
-        message.setGoLiveDate(nonsenseDate);
-        assertFalse("Unparseable date strings should invalidate a message (fail closed).",
-          message.isValidToday());
-    }
+  @Test
+  public void pastGoLiveDatesCanOmitTime() {
+    Message message = new Message();
+    String pastDate = "2000-04-12";
+    message.setGoLiveDate(pastDate);
+    assertTrue("Past go-live date omitting time should not invalidate message.",
+      message.isValidToday());
+  }
 
-    @Test
-    public void nullDatesPass() {
-        Message message = new Message();
-        message.setExpireDate(null);
-        message.setGoLiveDate(null);
-        assertTrue("Null go live or expire dates should not invalidate message.",
-          message.isValidToday());
-    }
+  @Test
+  public void filterOutImproperDates() {
+    Message message = new Message();
+    String nonsenseDate = "Not a date";
+    message.setGoLiveDate(nonsenseDate);
+    assertFalse("Unparseable date strings should invalidate a message (fail closed).",
+      message.isValidToday());
+  }
 
-    @Test
-    public void ignoresEmptyStringDates() {
-      Message message = new Message();
-      message.setExpireDate("");
-      message.setGoLiveDate("");
-      assertTrue("Empty date strings shouldn't invalidate a message",
-        message.isValidToday());
-    }
+  @Test
+  public void nullDatesPass() {
+    Message message = new Message();
+    message.setExpireDate(null);
+    message.setGoLiveDate(null);
+    assertTrue("Null go live or expire dates should not invalidate message.",
+      message.isValidToday());
+  }
+
+  @Test
+  public void ignoresEmptyStringDates() {
+    Message message = new Message();
+    message.setExpireDate("");
+    message.setGoLiveDate("");
+    assertTrue("Empty date strings shouldn't invalidate a message",
+      message.isValidToday());
+  }
 
   /**
    * Test that messages that expire later today are not considered expired.

--- a/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
@@ -14,7 +14,8 @@ public class ValidDateTest {
         Message message = new Message();
         String longAgoDate = "1999-12-31";
         message.setExpireDate(longAgoDate);
-        assertFalse(message.isValidToday());
+        assertFalse("Expired messages should not be valid.",
+          message.isValidToday());
     }
 
     @Test
@@ -22,7 +23,8 @@ public class ValidDateTest {
       Message message = new Message();
       String longAgoDateTime = "1999-12-31T13:21:14";
       message.setExpireDate(longAgoDateTime);
-      assertFalse(message.isValidToday());
+      assertFalse("Time-specified expire date-times should be honored.",
+        message.isValidToday());
     }
 
     @Test
@@ -30,7 +32,8 @@ public class ValidDateTest {
       Message message = new Message();
       String longFutureDate = "2999-12-31";
       message.setExpireDate(longFutureDate);
-      assertTrue(message.isValidToday());
+      assertTrue("Future expiration date omitting time should not invalidate message",
+        message.isValidToday());
     }
 
     @Test
@@ -38,7 +41,8 @@ public class ValidDateTest {
         Message message = new Message();
         String futureDate = "2100-12-31";
         message.setGoLiveDate(futureDate);
-        assertFalse(message.isValidToday());
+        assertFalse("Future go-live date without tim specified should invalidate message.",
+          message.isValidToday());
     }
 
     @Test
@@ -46,7 +50,8 @@ public class ValidDateTest {
       Message message = new Message();
       String pastDate = "2000-04-12T12:21:21";
       message.setGoLiveDate(pastDate);
-      assertTrue(message.isValidToday());
+      assertTrue("Messages with past go-live date-times with time specified should be valid.",
+        message.isValidToday());
     }
 
     @Test
@@ -54,7 +59,8 @@ public class ValidDateTest {
       Message message = new Message();
       String pastDate = "2000-04-12";
       message.setGoLiveDate(pastDate);
-      assertTrue(message.isValidToday());
+      assertTrue("Past go-live date omitting time should not invalidate message.",
+        message.isValidToday());
     }
 
     @Test
@@ -62,7 +68,8 @@ public class ValidDateTest {
         Message message = new Message();
         String nonsenseDate = "Not a date";
         message.setGoLiveDate(nonsenseDate);
-        assertFalse(message.isValidToday());
+        assertFalse("Unparseable date strings should invalidate a message (fail closed).",
+          message.isValidToday());
     }
 
     @Test
@@ -70,7 +77,8 @@ public class ValidDateTest {
         Message message = new Message();
         message.setExpireDate(null);
         message.setGoLiveDate(null);
-        assertTrue(message.isValidToday());
+        assertTrue("Null go live or expire dates should not invalidate message.",
+          message.isValidToday());
     }
 
     @Test
@@ -78,7 +86,8 @@ public class ValidDateTest {
       Message message = new Message();
       message.setExpireDate("");
       message.setGoLiveDate("");
-      assertTrue(message.isValidToday());
+      assertTrue("Empty date strings shouldn't invalidate a message",
+        message.isValidToday());
     }
 
   /**
@@ -112,7 +121,7 @@ public class ValidDateTest {
     // this works because LocalDateTime toString() --> ISO date-time format.
     message.setExpireDate(twoSecondsLaterThanNow.toString());
     message.setGoLiveDate("1900-01-01T03:00");
-    assertTrue("Should not be expired because two seconds from now is not expired.",
+    assertTrue("Message considered expired prematurely.",
       message.isValidToday());
   }
 
@@ -141,7 +150,7 @@ public class ValidDateTest {
 
     Message message = new Message();
     message.setGoLiveDate(twoSecondsLaterThanNow.toString());
-    assertFalse("Should not be valid because two seconds from now is not gone live.",
+    assertFalse("Message considered gone live prematurely.",
       message.isValidToday());
 
   }

--- a/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
@@ -77,6 +77,7 @@ public class ValidDateTest {
     LocalDateTime twoSecondsLaterThanNow = LocalDateTime.now().plusSeconds(2);
 
     Message message = new Message();
+    // this works because LocalDateTime toString() --> ISO date-time format.
     message.setExpireDate(twoSecondsLaterThanNow.toString());
     message.setGoLiveDate("1900-01-01T03:00");
     assertTrue("Should not be expired because two seconds from now is not expired.",

--- a/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
@@ -10,24 +10,6 @@ import org.junit.Test;
 public class ValidDateTest {
 
   @Test
-  public void filterOutExpiredDates() {
-    Message message = new Message();
-    String longAgoDate = "1999-12-31";
-    message.setExpireDate(longAgoDate);
-    assertFalse("Expired messages should not be valid.",
-      message.isValidToday());
-  }
-
-  @Test
-  public void expiredDatesCanBeSpecifiedWithTime() {
-    Message message = new Message();
-    String longAgoDateTime = "1999-12-31T13:21:14";
-    message.setExpireDate(longAgoDateTime);
-    assertFalse("Time-specified expire date-times should be honored.",
-      message.isValidToday());
-  }
-
-  @Test
   public void futureExpiredDatesCanOmitTime() {
     Message message = new Message();
     String longFutureDate = "2999-12-31";

--- a/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
@@ -91,8 +91,8 @@ public class ValidDateTest {
   }
 
   /**
-   * Test that messages that expire later today are not considered expired.
-   * That is, that expiration supports the THH:MM suffix on ISO date-times.
+   * Test that messages that expire later today are not considered expired. That is, that expiration
+   * supports the THH:MM suffix on ISO date-times.
    */
   @Test
   public void expiringLaterTodayIsNotExpired() throws InterruptedException {

--- a/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
@@ -18,11 +18,43 @@ public class ValidDateTest {
     }
 
     @Test
+    public void expiredDatesCanBeSpecifiedWithTime() {
+      Message message = new Message();
+      String longAgoDateTime = "1999-12-31T13:21:14";
+      message.setExpireDate(longAgoDateTime);
+      assertFalse(message.isValidToday());
+    }
+
+    @Test
+    public void futureExpiredDatesCanOmitTime() {
+      Message message = new Message();
+      String longFutureDate = "2999-12-31";
+      message.setExpireDate(longFutureDate);
+      assertTrue(message.isValidToday());
+    }
+
+    @Test
     public void filterOutNotYetLiveDates() {
         Message message = new Message();
         String futureDate = "2100-12-31";
         message.setGoLiveDate(futureDate);
         assertFalse(message.isValidToday());
+    }
+
+    @Test
+    public void pastGoLiveDatesYieldValidMessages() {
+      Message message = new Message();
+      String pastDate = "2000-04-12T12:21:21";
+      message.setGoLiveDate(pastDate);
+      assertTrue(message.isValidToday());
+    }
+
+    @Test
+    public void pastGoLiveDatesCanOmitTime() {
+      Message message = new Message();
+      String pastDate = "2000-04-12";
+      message.setGoLiveDate(pastDate);
+      assertTrue(message.isValidToday());
     }
 
     @Test

--- a/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
@@ -41,6 +41,14 @@ public class ValidDateTest {
         assertTrue(message.isValidToday());
     }
 
+    @Test
+    public void ignoresEmptyStringDates() {
+      Message message = new Message();
+      message.setExpireDate("");
+      message.setGoLiveDate("");
+      assertTrue(message.isValidToday());
+    }
+
   /**
    * Test that messages that expire later today are not considered expired.
    * That is, that expiration supports the THH:MM suffix on ISO date-times.

--- a/src/test/java/edu/wisc/my/messages/service/ExpiredMessagePredicateTest.java
+++ b/src/test/java/edu/wisc/my/messages/service/ExpiredMessagePredicateTest.java
@@ -1,0 +1,61 @@
+package edu.wisc.my.messages.service;
+
+import static org.junit.Assert.*;
+
+import edu.wisc.my.messages.model.Message;
+import java.time.LocalDateTime;
+import org.junit.Test;
+
+public class ExpiredMessagePredicateTest {
+
+  ExpiredMessagePredicate predicate = new ExpiredMessagePredicate(LocalDateTime.now());
+
+  @Test(expected = RuntimeException.class)
+  public void throwsOnNull() {
+    predicate.test(null);
+  }
+
+  @Test
+  public void messageWithGarbageExpirationDateIsConsideredExpired() {
+    Message brokenMessage = new Message();
+    brokenMessage.setExpireDate("Garbage");
+    assertTrue(predicate.test(brokenMessage));
+  }
+
+  @Test
+  public void expiredMessageIsExpired() {
+    Message expiredMessage = new Message();
+    expiredMessage.setExpireDate("2010-01-01");
+    assertTrue(predicate.test(expiredMessage));
+  }
+
+  @Test
+  public void preciselyExpiredMessageIsExpired() {
+    Message preciselyExpiredMessage = new Message();
+    preciselyExpiredMessage.setExpireDate("2001-04-12T17:35:24");
+    assertTrue(predicate.test(preciselyExpiredMessage));
+  }
+
+  @Test
+  public void notYetExpiredMessageIsNotExpired() {
+    ExpiredMessagePredicate expiredAsOfMillenium =
+      new ExpiredMessagePredicate(LocalDateTime.parse("2000-01-01T00:00:00"));
+
+    Message expiresAfterMillenium = new Message();
+    expiresAfterMillenium.setExpireDate("2012-11-29");
+
+    assertFalse(expiredAsOfMillenium.test(expiresAfterMillenium));
+  }
+
+  @Test
+  public void preciselyNotYetExpiredMessageIsNotExpired() {
+    ExpiredMessagePredicate expiredAsOfMillenium =
+      new ExpiredMessagePredicate(LocalDateTime.parse("2000-01-01T00:00:00"));
+
+    Message preciselyExpiresAfterMillenium = new Message();
+    preciselyExpiresAfterMillenium.setExpireDate("2015-12-22T09:00:00");
+
+    assertFalse(expiredAsOfMillenium.test(preciselyExpiresAfterMillenium));
+  }
+
+}

--- a/src/test/java/edu/wisc/my/messages/service/ExpiredMessagePredicateTest.java
+++ b/src/test/java/edu/wisc/my/messages/service/ExpiredMessagePredicateTest.java
@@ -1,6 +1,7 @@
 package edu.wisc.my.messages.service;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import edu.wisc.my.messages.model.Message;
 import java.time.LocalDateTime;

--- a/src/test/java/edu/wisc/my/messages/service/GoneLiveMessagePredicateTest.java
+++ b/src/test/java/edu/wisc/my/messages/service/GoneLiveMessagePredicateTest.java
@@ -1,0 +1,88 @@
+package edu.wisc.my.messages.service;
+
+import static org.junit.Assert.*;
+
+import edu.wisc.my.messages.model.Message;
+import java.time.LocalDateTime;
+import org.junit.Test;
+
+public class GoneLiveMessagePredicateTest {
+
+  @Test(expected = RuntimeException.class)
+  public void throwsOnNullMessage() {
+    GoneLiveMessagePredicate predicate = new GoneLiveMessagePredicate(LocalDateTime.now());
+    predicate.test(null);
+  }
+
+  @Test
+  public void messageWithoutGoLiveDateHasGoneLive() {
+    GoneLiveMessagePredicate predicate = new GoneLiveMessagePredicate(LocalDateTime.now());
+
+    Message message = new Message();
+    assertTrue(predicate.test(message));
+
+    message.setGoLiveDate("");
+    assertTrue(predicate.test(message));
+
+    message.setGoLiveDate(null);
+    assertTrue(predicate.test(message));
+  }
+
+  @Test
+  public void messageWithGarbageGoLiveDateHasNotGoneLive() {
+    GoneLiveMessagePredicate predicate = new GoneLiveMessagePredicate(LocalDateTime.now());
+
+    Message message = new Message();
+    message.setGoLiveDate("Garbage");
+
+    assertFalse(predicate.test(message));
+  }
+
+  @Test
+  public void messageWithPastGoLiveDateHasGoneLive() {
+    GoneLiveMessagePredicate predicate = new GoneLiveMessagePredicate(LocalDateTime.now());
+
+    Message message = new Message();
+    message.setGoLiveDate("2000-01-01");
+
+    assertTrue(predicate.test(message));
+
+  }
+
+  @Test
+  public void messageWithPrecisePastGoLiveDateHasGoneLive() {
+    GoneLiveMessagePredicate predicate = new GoneLiveMessagePredicate(LocalDateTime.now());
+
+    Message message = new Message();
+    message.setGoLiveDate("2000-01-01T00:04:01");
+
+    assertTrue(predicate.test(message));
+
+
+  }
+
+  @Test
+  public void messageWithFutureGoLiveDateHasNotGoneLive() {
+    GoneLiveMessagePredicate predicate =
+      new GoneLiveMessagePredicate(LocalDateTime.parse("2000-01-01T00:00:00"));
+
+    Message message = new Message();
+    message.setGoLiveDate("2010-01-01");
+
+    assertFalse(predicate.test(message));
+  }
+
+  @Test
+  public void messageWithPreciseFutureGoeLiveDatehasNotGoneLive() {
+
+    GoneLiveMessagePredicate predicate =
+      new GoneLiveMessagePredicate(LocalDateTime.parse("2000-01-01T00:00:00"));
+
+    Message message = new Message();
+    message.setGoLiveDate("2010-01-01T01:01:01");
+
+    assertFalse(predicate.test(message));
+
+  }
+
+}

--- a/src/test/java/edu/wisc/my/messages/service/GoneLiveMessagePredicateTest.java
+++ b/src/test/java/edu/wisc/my/messages/service/GoneLiveMessagePredicateTest.java
@@ -1,6 +1,7 @@
 package edu.wisc.my.messages.service;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import edu.wisc.my.messages.model.Message;
 import java.time.LocalDateTime;

--- a/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
+++ b/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
@@ -135,4 +135,37 @@ public class MessagesServiceTest {
 
     assertTrue(resultMessages.toList().isEmpty());
   }
+
+  @Test
+  public void includesUnExpiredMessages() {
+    MessagesService service = new MessagesService();
+
+    Message unexpiredMessage = new Message();
+    String longFutureDate = "2999-12-31";
+    unexpiredMessage.setExpireDate(longFutureDate);
+
+    Message preciselyUnexpiredMessage = new Message();
+    String preciseFutureDate = "2999-12-31T12:21:21";
+    preciselyUnexpiredMessage.setExpireDate(preciseFutureDate);
+
+    List<Message> unfilteredMessages = new ArrayList<>();
+    unfilteredMessages.add(unexpiredMessage);
+    unfilteredMessages.add(preciselyUnexpiredMessage);
+
+    MessagesFromTextFile messageSource = mock(MessagesFromTextFile.class);
+    when(messageSource.allMessages()).thenReturn(unfilteredMessages);
+
+    service.setMessageSource(messageSource);
+
+    User user = new User();
+
+    JSONObject result = service.filteredMessages(user);
+
+    assertNotNull(result);
+
+    JSONArray resultMessages = result.getJSONArray("messages");
+
+    assertEquals(2, resultMessages.length());
+  }
+
 }

--- a/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
+++ b/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
@@ -2,6 +2,7 @@ package edu.wisc.my.messages.service;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -102,4 +103,36 @@ public class MessagesServiceTest {
     assertEquals("uniqueMessageId", resultMessage.getString("id"));
   }
 
+  @Test
+  public void excludesExpiredMessages() {
+    MessagesService service = new MessagesService();
+
+    Message expiredMessage = new Message();
+    String longAgoDate = "1999-12-31";
+    expiredMessage.setExpireDate(longAgoDate);
+
+    Message preciselyExpiredMessage = new Message();
+    String preciseLongAgoDate = "1999-12-31T13:21:14";
+    preciselyExpiredMessage.setExpireDate(preciseLongAgoDate);
+
+    List<Message> unfilteredMessages = new ArrayList<>();
+    unfilteredMessages.add(expiredMessage);
+    unfilteredMessages.add(preciselyExpiredMessage);
+
+    MessagesFromTextFile messageSource = mock(MessagesFromTextFile.class);
+    when(messageSource.allMessages()).thenReturn(unfilteredMessages);
+
+    service.setMessageSource(messageSource);
+
+    User user = new User();
+
+    JSONObject result = service.filteredMessages(user);
+
+    assertNotNull(result);
+
+    JSONArray resultMessages = result.getJSONArray("messages");
+    assertNotNull(resultMessages);
+
+    assertTrue(resultMessages.toList().isEmpty());
+  }
 }

--- a/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
+++ b/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
@@ -1,20 +1,20 @@
 package edu.wisc.my.messages.service;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import edu.wisc.my.messages.data.MessagesFromTextFile;
 import edu.wisc.my.messages.model.AudienceFilter;
 import edu.wisc.my.messages.model.Message;
 import edu.wisc.my.messages.model.User;
-import org.json.JSONArray;
-import org.json.JSONObject;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.junit.Assert.*;
-
-import static org.mockito.Mockito.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
 
 public class MessagesServiceTest {
 

--- a/src/test/java/edu/wisc/my/messages/time/IsoDateTimeStringAfterPredicateTest.java
+++ b/src/test/java/edu/wisc/my/messages/time/IsoDateTimeStringAfterPredicateTest.java
@@ -1,6 +1,7 @@
 package edu.wisc.my.messages.time;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDateTime;
 import org.junit.Test;

--- a/src/test/java/edu/wisc/my/messages/time/IsoDateTimeStringAfterPredicateTest.java
+++ b/src/test/java/edu/wisc/my/messages/time/IsoDateTimeStringAfterPredicateTest.java
@@ -1,0 +1,65 @@
+package edu.wisc.my.messages.time;
+
+import static org.junit.Assert.*;
+
+import java.time.LocalDateTime;
+import org.junit.Test;
+
+public class IsoDateTimeStringAfterPredicateTest {
+
+  IsoDateTimeStringAfterPredicate afterNow =
+    new IsoDateTimeStringAfterPredicate(LocalDateTime.now());
+
+  /**
+   * Test that null is not after now.
+   */
+  @Test
+  public void nullIsNotAfter() {
+    assertFalse(afterNow.test(null));
+  }
+
+  /**
+   * Test that "" is not after now.
+   */
+  @Test
+  public void emptyIsNotAfter() {
+    assertFalse(afterNow.test(""));
+  }
+
+  /**
+   * Test that whitespace is not after now.
+   */
+  @Test
+  public void whitespaceIsNotAfter() {
+    assertFalse(afterNow.test("\t     \t"));
+  }
+
+  /**
+   * Test that input that cannot be parsed results in RuntimeException.
+   */
+  @Test(expected = RuntimeException.class)
+  public void garbageThrows() {
+    afterNow.test("Garbage");
+  }
+
+  @Test
+  public void uwWasNotIncorporatedAfterNow() {
+    assertFalse(afterNow.test("1848-07-26"));
+  }
+
+  @Test
+  public void uwWasNotIncorporatedAfterNowWhenTimeSpecified() {
+    assertFalse(afterNow.test("1848-07-26T13:45:22"));
+  }
+
+  @Test
+  public void uwTercentenialIsAfterNow() {
+    assertTrue(afterNow.test("2148-07-26"));
+  }
+
+  @Test
+  public void uwTercentenialIsAfterNowWhenTimeSpecified() {
+    assertTrue(afterNow.test("2148-07-26T04:17:32"));
+  }
+
+}

--- a/src/test/java/edu/wisc/my/messages/time/IsoDateTimeStringAfterPredicateTest.java
+++ b/src/test/java/edu/wisc/my/messages/time/IsoDateTimeStringAfterPredicateTest.java
@@ -62,4 +62,28 @@ public class IsoDateTimeStringAfterPredicateTest {
     assertTrue(afterNow.test("2148-07-26T04:17:32"));
   }
 
+  @Test
+  public void elevensiesIsAfterBreakfastDuringAGivenDay() {
+
+    LocalDateTime breakfastTime = LocalDateTime.parse("2010-01-01T07:00:00");
+    String elevensies = "2010-01-01T11:00:00";
+
+    IsoDateTimeStringAfterPredicate afterBreakfast =
+      new IsoDateTimeStringAfterPredicate(breakfastTime);
+
+    assertTrue(afterBreakfast.test(elevensies));
+  }
+
+  @Test
+  public void breakfastIsNotAfterElevensies() {
+
+    LocalDateTime elevensies = LocalDateTime.parse("2010-01-01T11:00:00");
+    String breakfastTime = "2010-01-01T07:00:00";
+
+    IsoDateTimeStringAfterPredicate afterElevensies =
+      new IsoDateTimeStringAfterPredicate(elevensies);
+
+    assertFalse(afterElevensies.test(breakfastTime));
+  }
+
 }

--- a/src/test/java/edu/wisc/my/messages/time/IsoDateTimeStringBeforePredicateTest.java
+++ b/src/test/java/edu/wisc/my/messages/time/IsoDateTimeStringBeforePredicateTest.java
@@ -61,4 +61,35 @@ public class IsoDateTimeStringBeforePredicateTest {
     assertFalse("July 26 2148 around 9a should not be before now.",
       beforeNowPredicate.test("2148-07-26T09:05:32"));
   }
+
+  /**
+   * Test that the predicate actually considers the time component of the date-time.
+   */
+  @Test
+  public void breakfastIsBeforeElevensies() {
+
+    LocalDateTime elevensies = LocalDateTime.parse("2000-01-01T11:00:00");
+    String breakfastTime = "2000-01-01T07:00:00";
+
+    IsoDateTimeStringBeforePredicate beforeElevensies =
+      new IsoDateTimeStringBeforePredicate(elevensies);
+
+    assertTrue(beforeElevensies.test(breakfastTime));
+  }
+
+  /**
+   * TEst that the predicate actually considers the time component of the date-time.
+   */
+  @Test
+  public void elevensiesIsNotBeforeBreakfast() {
+
+    LocalDateTime breakfastTime = LocalDateTime.parse("2000-01-01T07:00:00");
+    String elevensies = "2000-01-01T11:00:00";
+
+    IsoDateTimeStringBeforePredicate beforeBreakfast =
+      new IsoDateTimeStringBeforePredicate(breakfastTime);
+
+    assertFalse(beforeBreakfast.test(elevensies));
+  }
+
 }

--- a/src/test/java/edu/wisc/my/messages/time/IsoDateTimeStringBeforePredicateTest.java
+++ b/src/test/java/edu/wisc/my/messages/time/IsoDateTimeStringBeforePredicateTest.java
@@ -1,6 +1,7 @@
 package edu.wisc.my.messages.time;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDateTime;
 import org.junit.Test;

--- a/src/test/java/edu/wisc/my/messages/time/IsoDateTimeStringBeforePredicateTest.java
+++ b/src/test/java/edu/wisc/my/messages/time/IsoDateTimeStringBeforePredicateTest.java
@@ -1,0 +1,64 @@
+package edu.wisc.my.messages.time;
+
+import static org.junit.Assert.*;
+
+import java.time.LocalDateTime;
+import org.junit.Test;
+
+public class IsoDateTimeStringBeforePredicateTest {
+
+  private IsoDateTimeStringBeforePredicate beforeNowPredicate =
+    new IsoDateTimeStringBeforePredicate(LocalDateTime.now());
+
+  @Test
+  public void nullEvaluatesFalse() {
+    assertFalse("Null shouldn't be considered before now.", beforeNowPredicate.test(null));
+  }
+
+  @Test
+  public void emptyStringEvaluatesFalse() {
+    assertFalse("Empty string shouldn't be considered before now.", beforeNowPredicate.test(""));
+  }
+
+  @Test
+  public void whitespaceStringEvaluatesFalse() {
+    assertFalse("Whitespace shouldn't be considered before now.",
+      beforeNowPredicate.test("\t   \t"));
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void stringThatIsNotADateThrows() {
+    beforeNowPredicate.test("Garbage");
+  }
+
+  @Test
+  public void uwWasIncorporatedBeforeNow() {
+    assertTrue("July 26 1848 should be before now.",
+      beforeNowPredicate.test("1848-07-26"));
+  }
+
+  /**
+   * Test that even if the time of incorporation is specified to the second, it's still before now.
+   */
+  @Test
+  public void uwWasIncorporatedBeforeNowWhenTimeSpecific() {
+    assertTrue("July 26 1848 around 1p should be before now.",
+      beforeNowPredicate.test("1848-07-26T13:01:04"));
+  }
+
+  @Test
+  public void uwTercentenialIsNotBeforeNow() {
+    assertFalse("July 26 2148 should not be before now.",
+      beforeNowPredicate.test("2148-07-26"));
+  }
+
+  /**
+   * Test that even if the time of the tercentenial is specified to the second, it's still not
+   * before now.
+   */
+  @Test
+  public void uwTercentenialIsNotBeforeNowWhenTimeSpecific() {
+    assertFalse("July 26 2148 around 9a should not be before now.",
+      beforeNowPredicate.test("2148-07-26T09:05:32"));
+  }
+}


### PR DESCRIPTION
Parse go-live and expire instant strings as ISO `LocalDateTime` with optional time component.

+ Messages that expire later today are not yet expired.
+ Messages that go live later today are not yet valid.

Status quo `messages.json` supports (but does not require) this specificity; with this change so does `uPortal-messaging`.

----

[Definition of Done][]

<!-- Intended as a low-intrusion quick checklist reminder of Definition of Done.
     Routinely, take the opportunity to reflect and then tick off the did-the-right-thing-for items.
     Exceptionally, explain what's exceptional why.
-->

- [x] Documented
- [x] Fails gracefully (Bad date formats continue to fail closed)
- [x] Tested (Covered with new unit tests)
- [x] Secure (fails closed)
- [x] Adds no defects (**Arguable: does not support timezone-specified ISO date-times**)
- [x] Shippable. Path is clear to promote to production
- [x] Maintainable (Loving the Java 8 DateTime API)
- [x] Configurable (nothing to configure; the message date *is* the configuration)
- [x] Readable (Loving the Java 8 DateTime API)
- [x] Validates and sanitizes user input (fails gracefully closed on bad datetime strings)
- [x] Styled (Google Style)

[Definition of Done]: https://goo.gl/4JG2Z5
