### PR TITLE
build: start monitoring test coverage with Coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ src/main/.DS_Store
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ jdk:
 script: mvn package
 
 after_success:
-- mvn clean test cobertura:cobertura coveralls:cobertura
+- mvn clean cobertura:cobertura org.eluder.coveralls:coveralls-maven-plugin:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ jdk:
   - openjdk8
   - oraclejdk8
 script: mvn package
+
+after_success:
+- mvn clean test cobertura:cobertura coveralls:cobertura

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
   <plugin>
     <groupId>org.codehaus.mojo</groupId>
     <artifactId>cobertura-maven-plugin</artifactId>
-    <version>2.6</version>
+    <version>2.7</version>
     <configuration>
       <formats>
         <format>html</format>

--- a/pom.xml
+++ b/pom.xml
@@ -168,9 +168,6 @@
     <groupId>org.eluder.coveralls</groupId>
     <artifactId>coveralls-maven-plugin</artifactId>
     <version>4.3.0</version>
-    <configuration>
-      <repoToken>yourcoverallsprojectrepositorytoken</repoToken>
-    </configuration>
   </plugin>
 </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -176,41 +176,25 @@
     <version>4.3.0</version>
   </plugin>
   <plugin>
-    <groupId>com.qualinsight.mojo.cobertura</groupId>
-    <artifactId>qualinsight-mojo-cobertura-core</artifactId>
-    <version>2.0.0</version>
-    <executions>
-      <execution>
-        <id>instrument-ut</id>
-        <goals>
-          <goal>instrument-ut</goal>
-        </goals>
-      </execution>
-      <execution>
-        <id>instrument-it</id>
-        <goals>
-          <goal>instrument-it</goal>
-        </goals>
-      </execution>
-      <execution>
-        <id>report-ut-coverage</id>
-        <goals>
-          <goal>report-ut-coverage</goal>
-        </goals>
-      </execution>
-      <execution>
-        <id>report-it-coverage</id>
-        <goals>
-          <goal>report-it-coverage</goal>
-        </goals>
-      </execution>
-      <execution>
-        <id>report-overall-coverage</id>
-        <goals>
-          <goal>report-overall-coverage</goal>
-        </goals>
-      </execution>
-    </executions>
+    <groupId>org.codehaus.mojo</groupId>
+    <artifactId>cobertura-maven-plugin</artifactId>
+    <version>2.6</version>
+    <configuration>
+      <formats>
+        <format>html</format>
+        <format>xml</format>
+      </formats>
+      <maxmem>256m</maxmem>
+      <!-- aggregated reports for multi-module projects -->
+      <aggregate>true</aggregate>
+      <instrumentation>
+        <excludes>
+          <!-- Exclude generated classes -->
+          <exclude>**/*_.class</exclude>
+          <exclude>**/*_.java</exclude>
+        </excludes>
+      </instrumentation>
+    </configuration>
   </plugin>
 </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,12 @@
       	</exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>net.sourceforge.cobertura</groupId>
+      <artifactId>cobertura</artifactId>
+      <version>2.1.1</version>
+      <scope>test</scope>
+    </dependency>
     <!-- end::tests[] -->
   </dependencies>
 
@@ -168,6 +174,43 @@
     <groupId>org.eluder.coveralls</groupId>
     <artifactId>coveralls-maven-plugin</artifactId>
     <version>4.3.0</version>
+  </plugin>
+  <plugin>
+    <groupId>com.qualinsight.mojo.cobertura</groupId>
+    <artifactId>qualinsight-mojo-cobertura-core</artifactId>
+    <version>2.0.0</version>
+    <executions>
+      <execution>
+        <id>instrument-ut</id>
+        <goals>
+          <goal>instrument-ut</goal>
+        </goals>
+      </execution>
+      <execution>
+        <id>instrument-it</id>
+        <goals>
+          <goal>instrument-it</goal>
+        </goals>
+      </execution>
+      <execution>
+        <id>report-ut-coverage</id>
+        <goals>
+          <goal>report-ut-coverage</goal>
+        </goals>
+      </execution>
+      <execution>
+        <id>report-it-coverage</id>
+        <goals>
+          <goal>report-it-coverage</goal>
+        </goals>
+      </execution>
+      <execution>
+        <id>report-overall-coverage</id>
+        <goals>
+          <goal>report-overall-coverage</goal>
+        </goals>
+      </execution>
+    </executions>
   </plugin>
 </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -116,12 +116,6 @@
       	</exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>net.sourceforge.cobertura</groupId>
-      <artifactId>cobertura</artifactId>
-      <version>2.1.1</version>
-      <scope>test</scope>
-    </dependency>
     <!-- end::tests[] -->
   </dependencies>
 


### PR DESCRIPTION
(Demo: working in my fork of this repo and in the [corresponding Coveralls reporting](https://coveralls.io/github/apetro/uportal-messaging). 55% test coverage!)

Turns on Coveralls, by

1. Computing test coverage using Cobertura. (Chose Cobertura over other options because slightly familiar with from elsewhere.)
2. Reporting test coverage to Coveralls via Maven plugin.
3. (Out of band): turning on Coveralls for this org:repo on Coveralls webapp. (I set thresholds to try to stave off regression in test coverage.)

Commit history is messy because it took some poking around to find a working example to copy.

----
Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements

----

[Definition of Done][]

<!-- Intended as a low-intrusion quick checklist reminder of Definition of Done.
     Routinely, take the opportunity to reflect and then tick off the did-the-right-thing-for items.
     Exceptionally, explain what's exceptional why.
-->

- [x] Documented (self-documenting: it's `pom.xml` config.
- [x] Fails gracefully (Test coverage computation and Coveralls reporting is *after* Travis-CI considers the build successful. So criteria for successful build is still `mvn package` success, not dependent upon Coveralls service.
- [x] Tested (as demonstrated in my fork)
- [x] Secure (no security implications: this is reporting on public source code. Does not expose Coveralls token.)
- [x] Adds no defects (Build and tests still succeed.)
- [x] Shippable. Path is clear to promote to production (Nothing to ship)
- [x] Maintainable (Should just work)
- [x] Configurable (Cobertura and Coveralls have configuration that I hope we won't need.)
- [x] Readable (declarative Maven, it is what it is.)
- [x] Validates and sanitizes user input (no user input)
- [x] Styled (Google Style) (IntelliJ formatted the XML changes as best it could).

[Definition of Done]: https://goo.gl/4JG2Z5
