### PR TITLE
refactor(controller): idiomatic error handling and JSON production

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,12 +80,6 @@
       <artifactId>spring-boot-starter-data-rest</artifactId>
     </dependency>
     <dependency>
-      <groupId>net.sf.json-lib</groupId>
-      <artifactId>json-lib</artifactId>
-      <version>2.4</version>
-      <classifier>jdk15</classifier>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-tomcat</artifactId>
       <scope>provided</scope>
@@ -103,6 +97,11 @@
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
       <version>20171018</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.7</version>
     </dependency>
     <!-- tag::tests[] -->
     <dependency>

--- a/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
+++ b/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
@@ -2,10 +2,10 @@ package edu.wisc.my.messages.controller;
 
 import edu.wisc.my.messages.model.User;
 import edu.wisc.my.messages.service.MessagesService;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,17 +53,10 @@ public class MessagesController {
   }
 
   @RequestMapping("/")
-  public void index(HttpServletResponse response) {
-    try {
-      JSONObject responseObj = new JSONObject();
-      responseObj.put("status", "up");
-      response.getWriter().write(responseObj.toString());
-      response.setContentType("application/json");
-      response.setStatus(HttpServletResponse.SC_OK);
-    } catch (Exception e) {
-      logger.error("Issues happened while trying to write Status", e);
-      response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-    }
+  public Map<String, String> index() {
+    HashMap<String, String> statusResponse = new HashMap<>();
+    statusResponse.put("status", "up");
+    return statusResponse;
   }
 
   @Autowired

--- a/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
+++ b/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
@@ -36,9 +36,7 @@ public class MessagesController {
    * requesting user</li> </ul>
    */
   @GetMapping("/messages")
-  public void currentMessages(HttpServletRequest request,
-    HttpServletResponse response) {
-    response.setContentType("application/json");
+  public String currentMessages(HttpServletRequest request) {
 
     String isMemberOfHeader = request.getHeader("isMemberOf");
     Set<String> groups =
@@ -46,26 +44,12 @@ public class MessagesController {
     User user = new User();
     user.setGroups(groups);
 
-    JSONObject messages = messagesService.filteredMessages(user);
-    try {
-      response.getWriter().write(messages.toString());
-      response.setStatus(HttpServletResponse.SC_OK);
-    } catch (Exception e) {
-      response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-    }
+    return messagesService.filteredMessages(user).toString();
   }
 
   @GetMapping("/allMessages")
-  public void messages(HttpServletRequest request,
-    HttpServletResponse response) {
-    JSONObject json = messagesService.allMessages();
-    response.setContentType("application/json");
-    try {
-      response.getWriter().write(json.toString());
-      response.setStatus(HttpServletResponse.SC_OK);
-    } catch (Exception e) {
-      response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-    }
+  public String messages() {
+    return messagesService.allMessages().toString();
   }
 
   @RequestMapping("/")

--- a/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
+++ b/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
@@ -36,7 +36,7 @@ public class MessagesController {
    * requesting user</li> </ul>
    */
   @GetMapping("/messages")
-  public String currentMessages(HttpServletRequest request) {
+  public Map<String, Object> currentMessages(HttpServletRequest request) {
 
     String isMemberOfHeader = request.getHeader("isMemberOf");
     Set<String> groups =
@@ -44,12 +44,18 @@ public class MessagesController {
     User user = new User();
     user.setGroups(groups);
 
-    return messagesService.filteredMessages(user).toString();
+    Map<String, Object> responseMap = new HashMap<>();
+    responseMap.put("messages", messagesService.filteredMessages(user));
+
+    return responseMap;
   }
 
   @GetMapping("/allMessages")
-  public String messages() {
-    return messagesService.allMessages().toString();
+  public Map<String, Object> messages() {
+    Map<String, Object> responseMap = new HashMap<String, Object>();
+    responseMap.put("messages", messagesService.allMessages());
+
+    return responseMap;
   }
 
   @RequestMapping("/")

--- a/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
+++ b/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
@@ -9,16 +9,15 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Understands what HTTP requests are asking about messages, queries the MessagesService
  * accordingly, and replies in JSON.
  */
-@Controller
+@RestController
 public class MessagesController {
 
   protected final Logger logger = LoggerFactory.getLogger(getClass());
@@ -37,8 +36,7 @@ public class MessagesController {
    * requesting user</li> </ul>
    */
   @RequestMapping(value = "/messages", method = RequestMethod.GET)
-  public @ResponseBody
-  void currentMessages(HttpServletRequest request,
+  public void currentMessages(HttpServletRequest request,
     HttpServletResponse response) {
     response.setContentType("application/json");
 
@@ -58,8 +56,7 @@ public class MessagesController {
   }
 
   @RequestMapping(value = "/allMessages", method = RequestMethod.GET)
-  public @ResponseBody
-  void messages(HttpServletRequest request,
+  public void messages(HttpServletRequest request,
     HttpServletResponse response) {
     JSONObject json = messagesService.allMessages();
     response.setContentType("application/json");
@@ -72,8 +69,7 @@ public class MessagesController {
   }
 
   @RequestMapping("/")
-  public @ResponseBody
-  void index(HttpServletResponse response) {
+  public void index(HttpServletResponse response) {
     try {
       JSONObject responseObj = new JSONObject();
       responseObj.put("status", "up");

--- a/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
+++ b/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
@@ -9,8 +9,8 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -35,7 +35,7 @@ public class MessagesController {
    * not-after metadata on the message</li> <li>limited to groups none of which include the
    * requesting user</li> </ul>
    */
-  @RequestMapping(value = "/messages", method = RequestMethod.GET)
+  @GetMapping("/messages")
   public void currentMessages(HttpServletRequest request,
     HttpServletResponse response) {
     response.setContentType("application/json");
@@ -55,7 +55,7 @@ public class MessagesController {
     }
   }
 
-  @RequestMapping(value = "/allMessages", method = RequestMethod.GET)
+  @GetMapping("/allMessages")
   public void messages(HttpServletRequest request,
     HttpServletResponse response) {
     JSONObject json = messagesService.allMessages();

--- a/src/main/java/edu/wisc/my/messages/model/User.java
+++ b/src/main/java/edu/wisc/my/messages/model/User.java
@@ -2,7 +2,7 @@ package edu.wisc.my.messages.model;
 
 import java.util.HashSet;
 import java.util.Set;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 public class User {
 

--- a/src/main/java/edu/wisc/my/messages/service/AudienceFilterMessagePredicate.java
+++ b/src/main/java/edu/wisc/my/messages/service/AudienceFilterMessagePredicate.java
@@ -4,7 +4,7 @@ import edu.wisc.my.messages.model.AudienceFilter;
 import edu.wisc.my.messages.model.Message;
 import edu.wisc.my.messages.model.User;
 import java.util.function.Predicate;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 /**
  * Predicate that is true for messages where all of the potentially none audience filters of which

--- a/src/main/java/edu/wisc/my/messages/service/ExpiredMessagePredicate.java
+++ b/src/main/java/edu/wisc/my/messages/service/ExpiredMessagePredicate.java
@@ -4,7 +4,7 @@ import edu.wisc.my.messages.model.Message;
 import edu.wisc.my.messages.time.IsoDateTimeStringBeforePredicate;
 import java.time.LocalDateTime;
 import java.util.function.Predicate;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 /**
  * Predicate that is true for messages that are expired (or cannot be verified as not expired due to

--- a/src/main/java/edu/wisc/my/messages/service/GoneLiveMessagePredicate.java
+++ b/src/main/java/edu/wisc/my/messages/service/GoneLiveMessagePredicate.java
@@ -4,7 +4,7 @@ import edu.wisc.my.messages.model.Message;
 import edu.wisc.my.messages.time.IsoDateTimeStringAfterPredicate;
 import java.time.LocalDateTime;
 import java.util.function.Predicate;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 /**
  * Predicate that is true for messages that have gone live, either because they have no goLiveDate

--- a/src/main/java/edu/wisc/my/messages/service/MessagesService.java
+++ b/src/main/java/edu/wisc/my/messages/service/MessagesService.java
@@ -1,15 +1,12 @@
 package edu.wisc.my.messages.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import edu.wisc.my.messages.data.MessagesFromTextFile;
 import edu.wisc.my.messages.model.Message;
 import edu.wisc.my.messages.model.User;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
-import org.json.JSONArray;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,53 +19,25 @@ public class MessagesService {
 
   private MessagesFromTextFile messageSource;
 
-  public JSONObject allMessages() {
-    try {
-      List<Message> allMessages = messageSource.allMessages();
-
-      JSONArray jsonMessageArray = new JSONArray(allMessages);
-      JSONObject messagesJson = new JSONObject();
-      messagesJson.put("messages", jsonMessageArray);
-
-      return messagesJson;
-
-    } catch (Exception e) {
-      logger.warn("service exception " + e.getMessage());
-      JSONObject responseObj = new JSONObject();
-      responseObj.put("status", "error");
-      return responseObj;
-    }
+  public List<Message> allMessages() {
+    return messageSource.allMessages();
   }
 
-  public JSONObject filteredMessages(User user) {
+  public List<Message> filteredMessages(User user) {
 
     Predicate<Message> neitherPrematureNorExpired =
       new ExpiredMessagePredicate(LocalDateTime.now()).negate()
         .and(new GoneLiveMessagePredicate(LocalDateTime.now()));
 
+    // retain those messages with suitable dates and audiences
     Predicate<Message> retainMessage =
       neitherPrematureNorExpired.and(new AudienceFilterMessagePredicate(user));
 
-    JSONObject validMessages = new JSONObject();
-    JSONArray validMessageArray = new JSONArray();
-    ObjectMapper mapper = new ObjectMapper();
+    List<Message> validMessages = new ArrayList<>();
 
-    // needed this to get unit test working to support refactoring JSON out of the service layer
-    // at which point won't need this to unit test service layer.
-    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+    validMessages.addAll(messageSource.allMessages());
+    validMessages.removeIf(retainMessage.negate()); // remove the messages we're not retaining
 
-    try {
-      for (Message message : messageSource.allMessages()) {
-        if (retainMessage.test(message)) {
-          JSONObject validMessage = new JSONObject(message);
-          validMessageArray.put(validMessage);
-        }
-      }
-      validMessages.put("messages", validMessageArray);
-    } catch (Exception e) {
-      logger.warn("Date filter failure ", e);
-      return null;
-    }
     return validMessages;
   }
 

--- a/src/main/java/edu/wisc/my/messages/time/IsoDateTimeStringAfterPredicate.java
+++ b/src/main/java/edu/wisc/my/messages/time/IsoDateTimeStringAfterPredicate.java
@@ -3,7 +3,7 @@ package edu.wisc.my.messages.time;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.function.Predicate;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Predicate that is true for Strings that represent dates and date-times that are after the

--- a/src/main/java/edu/wisc/my/messages/time/IsoDateTimeStringBeforePredicate.java
+++ b/src/main/java/edu/wisc/my/messages/time/IsoDateTimeStringBeforePredicate.java
@@ -3,7 +3,7 @@ package edu.wisc.my.messages.time;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.function.Predicate;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Predicate that is true if the String represents a date or date-time in ISO format that is before

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerIT.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerIT.java
@@ -1,5 +1,6 @@
 package edu.wisc.my.messages.controller;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import java.net.URL;
@@ -36,5 +37,13 @@ public class MessagesControllerIT {
     ResponseEntity<String> response = template.getForEntity(base.toString(),
       String.class);
     assertThat(response.getBody(), StringContains.containsString("status"));
+  }
+
+  @Test
+  public void nonexistentPathYields404() throws Exception {
+    ResponseEntity<String> response =
+      template.getForEntity(base.toString() + "someGoofyPath", String.class);
+    assertEquals("Missing path should yield 404 not found response.",
+      404, response.getStatusCodeValue());
   }
 }

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
@@ -30,7 +30,7 @@ public class MessagesControllerTest {
   }
 
   @Test
-  public void allMessages() throws Exception {
+  public void filteredMessagesIncludesAMessage() throws Exception {
     mvc.perform(MockMvcRequestBuilders.get("/messages").accept(MediaType.APPLICATION_JSON))
       .andExpect(status().isOk())
       .andExpect(content().string(StringContains.containsString("titleShort")));

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
@@ -31,8 +31,32 @@ public class MessagesControllerTest {
 
   @Test
   public void filteredMessagesIncludesAMessage() throws Exception {
+
+    String expectedJson = "{\n"
+      + "  \"messages\": [\n"
+      + "    {\n"
+      + "      \"data\": {},\n"
+      + "      \"messageType\": \"announcement\",\n"
+      + "      \"moreInfoButton\": {\n"
+      + "        \"label\": \"More info\",\n"
+      + "        \"url\": \"https://www.apereo.org/content/2018-open-apereo-montreal-quebec\"\n"
+      + "      },\n"
+      + "      \"actionButton\": {\n"
+      + "        \"label\": \"Add to home\",\n"
+      + "        \"url\": \"addToHome/open-apereo\"\n"
+      + "      },\n"
+      + "      \"validToday\": true,\n"
+      + "      \"description\": \"This announcement is not filtered by groups.\",\n"
+      + "      \"titleShort\": \"Not filtered by audience\",\n"
+      + "      \"id\": \"has-no-audience-filter\",\n"
+      + "      \"descriptionShort\": \"Not filtered by groups.\",\n"
+      + "      \"title\": \"An announcement lacking an audience filter.\"\n"
+      + "    }\n"
+      + "  ]\n"
+      + "}";
+
     mvc.perform(MockMvcRequestBuilders.get("/messages").accept(MediaType.APPLICATION_JSON))
       .andExpect(status().isOk())
-      .andExpect(content().string(StringContains.containsString("titleShort")));
+      .andExpect(content().json(expectedJson));
   }
 }

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
@@ -26,7 +26,7 @@ public class MessagesControllerTest {
   public void siteIsUp() throws Exception {
     mvc.perform(MockMvcRequestBuilders.get("/").accept(MediaType.APPLICATION_JSON))
       .andExpect(status().isOk())
-      .andExpect(content().string(StringContains.containsString("status")));
+      .andExpect(content().json("{\"status\":\"up\"}"));
   }
 
   @Test

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
@@ -26,6 +26,7 @@ public class MessagesControllerTest {
   public void siteIsUp() throws Exception {
     mvc.perform(MockMvcRequestBuilders.get("/").accept(MediaType.APPLICATION_JSON))
       .andExpect(status().isOk())
+      .andExpect(content().contentTypeCompatibleWith("application/json"))
       .andExpect(content().json("{\"status\":\"up\"}"));
   }
 
@@ -57,6 +58,7 @@ public class MessagesControllerTest {
 
     mvc.perform(MockMvcRequestBuilders.get("/messages").accept(MediaType.APPLICATION_JSON))
       .andExpect(status().isOk())
+      .andExpect(content().contentTypeCompatibleWith("application/json"))
       .andExpect(content().json(expectedJson));
   }
 }

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
@@ -3,7 +3,6 @@ package edu.wisc.my.messages.controller;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.hamcrest.core.StringContains;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
@@ -46,7 +46,6 @@ public class MessagesControllerTest {
       + "        \"label\": \"Add to home\",\n"
       + "        \"url\": \"addToHome/open-apereo\"\n"
       + "      },\n"
-      + "      \"validToday\": true,\n"
       + "      \"description\": \"This announcement is not filtered by groups.\",\n"
       + "      \"titleShort\": \"Not filtered by audience\",\n"
       + "      \"id\": \"has-no-audience-filter\",\n"

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
@@ -7,13 +7,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import edu.wisc.my.messages.model.Message;
 import edu.wisc.my.messages.model.User;
 import edu.wisc.my.messages.service.MessagesService;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import org.json.JSONObject;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -35,10 +36,10 @@ public class MessagesControllerUnitTest {
     controller.setMessagesService(mockService);
 
     HttpServletRequest mockRequest = mock(HttpServletRequest.class);
-    JSONObject mockJsonObject = mock(JSONObject.class);
+    List<Message> messages = new ArrayList<>();
 
     when(mockRequest.getHeader("isMemberOf")).thenReturn("group1;group2;");
-    when(mockService.filteredMessages(any())).thenReturn(mockJsonObject);
+    when(mockService.filteredMessages(any())).thenReturn(messages);
 
     controller.currentMessages(mockRequest);
 
@@ -62,9 +63,10 @@ public class MessagesControllerUnitTest {
     controller.setMessagesService(mockService);
 
     HttpServletRequest mockRequest = mock(HttpServletRequest.class);
-    JSONObject mockJsonObject = mock(JSONObject.class);
 
-    when(mockService.filteredMessages(any())).thenReturn(mockJsonObject);
+    List<Message> messages = new ArrayList<>();
+
+    when(mockService.filteredMessages(any())).thenReturn(messages);
     Set<String> groups = new HashSet<>();
     groups.add("someGroup");
     groups.add("someOtherGroup");

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
@@ -35,13 +35,12 @@ public class MessagesControllerUnitTest {
     controller.setMessagesService(mockService);
 
     HttpServletRequest mockRequest = mock(HttpServletRequest.class);
-    HttpServletResponse mockResponse = mock(HttpServletResponse.class);
     JSONObject mockJsonObject = mock(JSONObject.class);
 
     when(mockRequest.getHeader("isMemberOf")).thenReturn("group1;group2;");
     when(mockService.filteredMessages(any())).thenReturn(mockJsonObject);
 
-    controller.currentMessages(mockRequest, mockResponse);
+    controller.currentMessages(mockRequest);
 
     verify(mockRequest).getHeader("isMemberOf");
     verify(mockParser).groupsFromHeaderValue("group1;group2;");
@@ -63,7 +62,6 @@ public class MessagesControllerUnitTest {
     controller.setMessagesService(mockService);
 
     HttpServletRequest mockRequest = mock(HttpServletRequest.class);
-    HttpServletResponse mockResponse = mock(HttpServletResponse.class);
     JSONObject mockJsonObject = mock(JSONObject.class);
 
     when(mockService.filteredMessages(any())).thenReturn(mockJsonObject);
@@ -73,7 +71,7 @@ public class MessagesControllerUnitTest {
     groups.add("yetAnotherGroup");
     when(mockParser.groupsFromHeaderValue(anyString())).thenReturn(groups);
 
-    controller.currentMessages(mockRequest, mockResponse);
+    controller.currentMessages(mockRequest);
 
     ArgumentCaptor<User> argument = ArgumentCaptor.forClass(User.class);
     verify(mockService).filteredMessages(argument.capture());

--- a/src/test/java/edu/wisc/my/messages/model/UserTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/UserTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 public class UserTest {
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test(expected = NullPointerException.class)
   public void cannotSetGroupsToNull() {
     User user = new User();
     user.setGroups(null);

--- a/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
+++ b/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
@@ -13,8 +13,6 @@ import edu.wisc.my.messages.model.Message;
 import edu.wisc.my.messages.model.User;
 import java.util.ArrayList;
 import java.util.List;
-import org.json.JSONArray;
-import org.json.JSONObject;
 import org.junit.Test;
 
 public class MessagesServiceTest {
@@ -42,21 +40,19 @@ public class MessagesServiceTest {
 
     service.setMessageSource(messageSource);
 
-    JSONObject result = service.allMessages();
+    List<Message> result = service.allMessages();
 
     // result should be a message array containing both messages
 
     assertNotNull(result);
 
-    JSONArray resultMessages = result.getJSONArray("messages");
-    assertNotNull(resultMessages);
-    assertEquals(2, resultMessages.length());
+    assertEquals(2, result.size());
 
-    JSONObject firstResultMessage = resultMessages.getJSONObject(0);
-    assertEquals("uniqueMessageId-1", firstResultMessage.getString("id"));
+    Message firstResultMessage = result.get(0);
+    assertEquals("uniqueMessageId-1", firstResultMessage.getId());
 
-    JSONObject secondResultMessage = resultMessages.getJSONObject(1);
-    assertEquals("anotherMessageId-2", secondResultMessage.getString("id"));
+    Message secondResultMessage = result.get(1);
+    assertEquals("anotherMessageId-2", secondResultMessage.getId());
   }
 
 
@@ -89,18 +85,15 @@ public class MessagesServiceTest {
 
     User user = new User();
 
-    JSONObject result = service.filteredMessages(user);
+    List<Message> result = service.filteredMessages(user);
 
     assertNotNull(result);
 
-    JSONArray resultMessages = result.getJSONArray("messages");
-    assertNotNull(resultMessages);
+    assertEquals(1, result.size());
 
-    assertEquals(1, resultMessages.length());
+    Message resultMessage = result.get(0);
 
-    JSONObject resultMessage = resultMessages.getJSONObject(0);
-
-    assertEquals("uniqueMessageId", resultMessage.getString("id"));
+    assertEquals("uniqueMessageId", resultMessage.getId());
   }
 
   @Test
@@ -126,14 +119,11 @@ public class MessagesServiceTest {
 
     User user = new User();
 
-    JSONObject result = service.filteredMessages(user);
+    List<Message> result = service.filteredMessages(user);
 
     assertNotNull(result);
 
-    JSONArray resultMessages = result.getJSONArray("messages");
-    assertNotNull(resultMessages);
-
-    assertTrue(resultMessages.toList().isEmpty());
+    assertTrue(result.isEmpty());
   }
 
   @Test
@@ -159,13 +149,12 @@ public class MessagesServiceTest {
 
     User user = new User();
 
-    JSONObject result = service.filteredMessages(user);
+    List<Message> result = service.filteredMessages(user);
 
     assertNotNull(result);
 
-    JSONArray resultMessages = result.getJSONArray("messages");
 
-    assertEquals(2, resultMessages.length());
+    assertEquals(2, result.size());
   }
 
 }

--- a/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
+++ b/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
@@ -153,7 +153,6 @@ public class MessagesServiceTest {
 
     assertNotNull(result);
 
-
     assertEquals(2, result.size());
   }
 


### PR DESCRIPTION
Adopts more idiomatic JSON generation, error handling, and in general Spring WebMVC (as it underlies Spring Boot) idioms.

----
Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements

----

[Definition of Done][]

<!-- Intended as a low-intrusion quick checklist reminder of Definition of Done.
     Routinely, take the opportunity to reflect and then tick off the did-the-right-thing-for items.
     Exceptionally, explain what's exceptional why.
-->

- [x] Documented (Self-documenting-ness is one point of using idioms. *Doesn't* add clarity on just what JSON it ought to be producing, but doesn't make that any worse. (And indeed starts to cover the JSON representation with unit tests.)
- [x] Fails gracefully (Spring WebMVC / Boot fails however it fails).
- [x] Tested
- [x] Secure (No security implications)
- [x] Adds no defects (All the tests still pass.)
- [x] Shippable. (No less ready to go to production. There will probably be some reconciling to do between the evolving JSON representation here and that expected in `uPortal-app-framework`.)
- [x] Maintainable (One fewer JSON library dependency.)
- [x] Configurable (Spring is however configurable it is. `@JSONIgnore` even starts being honored.
- [x] Readable (More idiomatic is more readable.)
- [x] Validates and sanitizes user input (no less so than before)
- [x] Styled (Google Style)

[Definition of Done]: https://goo.gl/4JG2Z5
