### PR TITLE
refactor: rename Controller methods to match the paths they service

### DIFF
--- a/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
+++ b/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
@@ -36,7 +36,7 @@ public class MessagesController {
    * requesting user</li> </ul>
    */
   @GetMapping("/messages")
-  public Map<String, Object> currentMessages(HttpServletRequest request) {
+  public Map<String, Object> messages(HttpServletRequest request) {
 
     String isMemberOfHeader = request.getHeader("isMemberOf");
     Set<String> groups =
@@ -51,7 +51,7 @@ public class MessagesController {
   }
 
   @GetMapping("/allMessages")
-  public Map<String, Object> messages() {
+  public Map<String, Object> allMessages() {
     Map<String, Object> responseMap = new HashMap<String, Object>();
     responseMap.put("messages", messagesService.allMessages());
 

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
@@ -99,7 +99,7 @@ public class MessagesControllerUnitTest {
 
     when(mockService.allMessages()).thenReturn(messages);
 
-    Map<String, Object> result = controller.messages();
+    Map<String, Object> result = controller.allMessages();
 
     assertSame(messages, result.get("messages"));
   }

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
@@ -41,7 +41,7 @@ public class MessagesControllerUnitTest {
     when(mockRequest.getHeader("isMemberOf")).thenReturn("group1;group2;");
     when(mockService.filteredMessages(any())).thenReturn(messages);
 
-    controller.currentMessages(mockRequest);
+    controller.messages(mockRequest);
 
     verify(mockRequest).getHeader("isMemberOf");
     verify(mockParser).groupsFromHeaderValue("group1;group2;");
@@ -73,7 +73,7 @@ public class MessagesControllerUnitTest {
     groups.add("yetAnotherGroup");
     when(mockParser.groupsFromHeaderValue(anyString())).thenReturn(groups);
 
-    controller.currentMessages(mockRequest);
+    controller.messages(mockRequest);
 
     ArgumentCaptor<User> argument = ArgumentCaptor.forClass(User.class);
     verify(mockService).filteredMessages(argument.capture());


### PR DESCRIPTION
Makes the Controller slightly more idiomatic.

----
Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements

----

[Definition of Done][]

<!-- Intended as a low-intrusion quick checklist reminder of Definition of Done.
     Routinely, take the opportunity to reflect and then tick off the did-the-right-thing-for items.
     Exceptionally, explain what's exceptional why.
-->

- [x] Documented (self-documenting :smile:)
- [x] Fails gracefully (Spring WebMVC still does what it does in this regard).
- [x] Tested (Covered by unit tests.)
- [x] Secure (No security implications.)
- [x] Adds no defects (Existing tests still pass.)
- [x] Shippable
- [x] Maintainable (Matching method names to paths is easier to understand and so easier to maintain.)
- [x] Configurable (method names don't constrain what paths those methods service.)
- [x] Readable (correspondence between method names and paths is more readable.)
- [x] Validates and sanitizes user input (no differential handling of input)
- [x] Styled (Google Style)

[Definition of Done]: https://goo.gl/4JG2Z5
