### PR TITLE
feat: add single message path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -79,10 +79,10 @@ Security:
 WARNING: Does not apply any access control other than filtering to messages applicable to the user's groups. If 
 additional access control is needed (it may not be needed), implement it at the container layer. 
 
-### {*/allMessages*}
+### {*/admin/allMessages*}
 calls:
 ``` java
-  @RequestMapping(value = "/allMessages", method = RequestMethod.GET)
+  @RequestMapping(value = "/admin/allMessages", method = RequestMethod.GET)
   public @ResponseBody
   void messages(HttpServletRequest request,
     HttpServletResponse response)
@@ -96,4 +96,4 @@ Intended as an administrative or troubleshooting view on the data.
 
 Security:
 WARNING: Does not apply any access control. Implement access control at the container layer. Whatever access control
-is appropriate, apply it to the `/allMessages` path at e.g. the `httpd` layer.
+is appropriate, apply it to the `/admin/allMessages` path at e.g. the `httpd` layer. The `/admin` prefix is intended to facilitate this.

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,20 @@ Security:
 WARNING: Does not apply any access control other than filtering to messages applicable to the user's groups. If
 additional access control is needed (it may not be needed), implement it at the container layer.
 
+### `/message/{id}`
+
+Implemented in `MessagesController`.
+
+Responds:
+
++ A JSON representation of the message with the given `id`, or
++ `404 NOT FOUND` if no message with requested `id`, or
++ `403 FORBIDDEN` if message exists but is expired, premature, or the requesting user is not in its audience.
+
+description:
+Intended as view on a specific message.
+
+
 ### `/admin/allMessages`
 
 Implemented in `MessagesController`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,11 +31,12 @@ To run locally, ```$ mvn spring-boot:run ``` will compile and run this microserv
 
 Implemented in `MessagesController`.
 
-returns:
+Responds:
 
 ```
 {"status":"up"}
 ```
+
 description:
 This endpoint returns a small json object indicating that the status of the application is healthy.
 
@@ -43,7 +44,7 @@ This endpoint returns a small json object indicating that the status of the appl
 
 Implemented in `MessagesController`.
 
-returns:
+Responds:
 A JSON object containing messages filtered to the viewing user and the current context.
 
 description:
@@ -75,7 +76,7 @@ additional access control is needed (it may not be needed), implement it at the 
 
 Implemented in `MessagesController`.
 
-returns:
+Responds:
 A JSON object, containing every known message, regardless of all criteria.
 
 description:
@@ -89,7 +90,7 @@ is appropriate, apply it to the `/admin/allMessages` path at e.g. the `httpd` la
 
 Implemented in `MessagesController`.
 
-returns:
+Responds:
 
 + A JSON representation of the message with the given `id`, or
 + 404 NOT FOUND if no message with requested `id`

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,8 +25,6 @@ To run locally, ```$ mvn spring-boot:run ``` will compile and run this microserv
 
 ## Endpoints
 
-
-
 ### `/`
 
 Implemented in `MessagesController`.
@@ -84,7 +82,6 @@ Responds:
 
 description:
 Intended as view on a specific message.
-
 
 ### `/admin/allMessages`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,26 +2,26 @@
 
 This messaging microservice is intended for use with [uportal-home](https://github.com/uPortal-Project/uportal-home).
 
-uPortal messages include both notifications and announcements, and can be tailored for audiences as small as one person. 
+uPortal messages include both notifications and announcements, and can be tailored for audiences as small as one person.
 
 ## What is a message?
 
-A message is an announcement or notification which can be targeted to an entire user population, a subset of the population, or a single user. 
+A message is an announcement or notification which can be targeted to an entire user population, a subset of the population, or a single user.
 
-This microservice processes messages in json form. The details of how that json is structured are found in the uportal-app-framework project's [documentation](https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/messaging-implementation.md). 
+This microservice processes messages in json form. The details of how that json is structured are found in the uportal-app-framework project's [documentation](https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/messaging-implementation.md).
 
 ## Configuration
 
-Set the source of your messages in the ``application.properties`` file. In this example, we've selected a json file in our resources directory. 
+Set the source of your messages in the ``application.properties`` file. In this example, we've selected a json file in our resources directory.
 ``` javascript
 message.source=classpath:messages.json
 ```
 
 ## To Build
 
-This project uses maven. ```$ mvn package ``` will build a warfile for deployment. 
+This project uses maven. ```$ mvn package ``` will build a warfile for deployment.
 
-To run locally, ```$ mvn spring-boot:run ``` will compile and run this microservice. 
+To run locally, ```$ mvn spring-boot:run ``` will compile and run this microservice.
 
 ## Endpoints
 
@@ -30,10 +30,10 @@ To run locally, ```$ mvn spring-boot:run ``` will compile and run this microserv
 ### `/`
 
 calls:
-```java 
+```java
     @RequestMapping("/")
     public @ResponseBody
-    void index(HttpServletResponse response)   
+    void index(HttpServletResponse response)
 ```
 returns:
 
@@ -41,7 +41,7 @@ returns:
 {"status":"up"}
 ```
 description:
-This endpoint returns a small json object indicating that the status of the application is healthy. 
+This endpoint returns a small json object indicating that the status of the application is healthy.
 
 ### `/messages`
 
@@ -49,13 +49,13 @@ calls:
 ``` java
    @RequestMapping(value="/messages", method=RequestMethod.GET)
     public @ResponseBody void messages(HttpServletRequest request,
-        HttpServletResponse response) 
+        HttpServletResponse response)
 ```
 returns:
 A JSON object containing messages filtered to the viewing user and the current context.
 
 description:
-Intended as the primary endpoint for servicing typical users. The idea is to move all the complication of message 
+Intended as the primary endpoint for servicing typical users. The idea is to move all the complication of message
 resolution server-side into this microservice so that a typical client can request this data and uncritically render it.
 
 Currently filters to:
@@ -66,18 +66,18 @@ specified in ISO format, as in `2018-02-14` or `2018-02-14:09:46:00`), AND
 
 Expectations:
 
-+ `isMemberOf` header conveying semicolon-delimited group memberships. (This practice is typical in UW-Madison 
-Shibboleth SP implementation.) Fails gracefully yet safely: if this header is not present, considers the user a member 
++ `isMemberOf` header conveying semicolon-delimited group memberships. (This practice is typical in UW-Madison
+Shibboleth SP implementation.) Fails gracefully yet safely: if this header is not present, considers the user a member
 of no groups.
 
 Versioning:
 The details of the filtering are NOT a semantically versioned aspect of the API. That is to say, what is versioned
-here is that `/messages` returns the messages appropriate for the requesting user. Increasing sophistication in what 
+here is that `/messages` returns the messages appropriate for the requesting user. Increasing sophistication in what
 "appropriate" means is not a breaking change.
 
 Security:
-WARNING: Does not apply any access control other than filtering to messages applicable to the user's groups. If 
-additional access control is needed (it may not be needed), implement it at the container layer. 
+WARNING: Does not apply any access control other than filtering to messages applicable to the user's groups. If
+additional access control is needed (it may not be needed), implement it at the container layer.
 
 ### `/admin/allMessages`
 calls:
@@ -89,7 +89,7 @@ calls:
 ```
 
 returns:
-A JSON object, containing every known message, regardless of all criteria. 
+A JSON object, containing every known message, regardless of all criteria.
 
 description:
 Intended as an administrative or troubleshooting view on the data.
@@ -109,7 +109,6 @@ description:
 Intended as an administrative or troubleshooting view on the data for a specific message.
 
 Security:
-WARNING: Does not apply any access control. Implement access control at the container layer. 
-Whatever access control is appropriate, apply it to the `/admin/message` path at e.g. the `httpd` 
+WARNING: Does not apply any access control. Implement access control at the container layer.
+Whatever access control is appropriate, apply it to the `/admin/message` path at e.g. the `httpd`
 layer. The `/admin` prefix is intended to facilitate this.
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ To run locally, ```$ mvn spring-boot:run ``` will compile and run this microserv
 
 
 
-### {*/*}
+### `/`
 
 calls:
 ```java 
@@ -43,7 +43,7 @@ returns:
 description:
 This endpoint returns a small json object indicating that the status of the application is healthy. 
 
-### {*/messages*}
+### `/messages`
 
 calls:
 ``` java
@@ -79,7 +79,7 @@ Security:
 WARNING: Does not apply any access control other than filtering to messages applicable to the user's groups. If 
 additional access control is needed (it may not be needed), implement it at the container layer. 
 
-### {*/admin/allMessages*}
+### `/admin/allMessages`
 calls:
 ``` java
   @RequestMapping(value = "/admin/allMessages", method = RequestMethod.GET)
@@ -98,7 +98,7 @@ Security:
 WARNING: Does not apply any access control. Implement access control at the container layer. Whatever access control
 is appropriate, apply it to the `/admin/allMessages` path at e.g. the `httpd` layer. The `/admin` prefix is intended to facilitate this.
 
-### {*/admin/message/{id}*}
+### `/admin/message/{id}`
 
 returns:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,3 +97,19 @@ Intended as an administrative or troubleshooting view on the data.
 Security:
 WARNING: Does not apply any access control. Implement access control at the container layer. Whatever access control
 is appropriate, apply it to the `/admin/allMessages` path at e.g. the `httpd` layer. The `/admin` prefix is intended to facilitate this.
+
+### {*/admin/message/{id}*}
+
+returns:
+
++ A JSON representation of the message with the given `id`, or
++ 404 NOT FOUND if no message with requested `id`
+
+description:
+Intended as an administrative or troubleshooting view on the data for a specific message.
+
+Security:
+WARNING: Does not apply any access control. Implement access control at the container layer. 
+Whatever access control is appropriate, apply it to the `/admin/message` path at e.g. the `httpd` 
+layer. The `/admin` prefix is intended to facilitate this.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,12 +29,8 @@ To run locally, ```$ mvn spring-boot:run ``` will compile and run this microserv
 
 ### `/`
 
-calls:
-```java
-    @RequestMapping("/")
-    public @ResponseBody
-    void index(HttpServletResponse response)
-```
+Implemented in `MessagesController`.
+
 returns:
 
 ```
@@ -45,12 +41,8 @@ This endpoint returns a small json object indicating that the status of the appl
 
 ### `/messages`
 
-calls:
-``` java
-   @RequestMapping(value="/messages", method=RequestMethod.GET)
-    public @ResponseBody void messages(HttpServletRequest request,
-        HttpServletResponse response)
-```
+Implemented in `MessagesController`.
+
 returns:
 A JSON object containing messages filtered to the viewing user and the current context.
 
@@ -80,13 +72,8 @@ WARNING: Does not apply any access control other than filtering to messages appl
 additional access control is needed (it may not be needed), implement it at the container layer.
 
 ### `/admin/allMessages`
-calls:
-``` java
-  @RequestMapping(value = "/admin/allMessages", method = RequestMethod.GET)
-  public @ResponseBody
-  void messages(HttpServletRequest request,
-    HttpServletResponse response)
-```
+
+Implemented in `MessagesController`.
 
 returns:
 A JSON object, containing every known message, regardless of all criteria.
@@ -99,6 +86,8 @@ WARNING: Does not apply any access control. Implement access control at the cont
 is appropriate, apply it to the `/admin/allMessages` path at e.g. the `httpd` layer. The `/admin` prefix is intended to facilitate this.
 
 ### `/admin/message/{id}`
+
+Implemented in `MessagesController`.
 
 returns:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ Responds:
 {"status":"up"}
 ```
 
-description:
+Description:
 This endpoint returns a small json object indicating that the status of the application is healthy.
 
 ### `/messages`
@@ -80,7 +80,7 @@ Responds:
 + `404 NOT FOUND` if no message with requested `id`, or
 + `403 FORBIDDEN` if message exists but is expired, premature, or the requesting user is not in its audience.
 
-description:
+Description:
 Intended as view on a specific message.
 
 ### `/admin/allMessages`
@@ -90,7 +90,7 @@ Implemented in `MessagesController`.
 Responds:
 A JSON object, containing every known message, regardless of all criteria.
 
-description:
+Description:
 Intended as an administrative or troubleshooting view on the data.
 
 Security:
@@ -106,7 +106,7 @@ Responds:
 + A JSON representation of the message with the given `id`, or
 + 404 NOT FOUND if no message with requested `id`
 
-description:
+Description:
 Intended as an administrative or troubleshooting view on the data for a specific message.
 
 Security:

--- a/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
+++ b/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
@@ -1,5 +1,6 @@
 package edu.wisc.my.messages.controller;
 
+import edu.wisc.my.messages.model.Message;
 import edu.wisc.my.messages.model.User;
 import edu.wisc.my.messages.service.MessagesService;
 import java.util.HashMap;
@@ -10,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -81,4 +83,14 @@ public class MessagesController {
     this.isMemberOfHeaderParser = isMemberOfHeaderParser;
   }
 
+  /**
+   * Get a specific message regardless of the message's audience, dates, etc.
+   *
+   * @param id message ID to match
+   * @return Message with matching ID
+   */
+  @RequestMapping("/admin/message/{id}")
+  public Message messageById(@PathVariable String id) {
+    return messagesService.messageById(id);
+  }
 }

--- a/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
+++ b/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
@@ -50,6 +50,11 @@ public class MessagesController {
     return responseMap;
   }
 
+  /**
+   * Get all the messages in the system, regardless of audience, dates, etc.
+   *
+   * @return Map where key "messages" has value List of all Messages.
+   */
   @GetMapping("/admin/allMessages")
   public Map<String, Object> allMessages() {
     Map<String, Object> responseMap = new HashMap<String, Object>();

--- a/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
+++ b/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
@@ -90,7 +90,7 @@ public class MessagesController {
    * @return Message with matching ID
    */
   @RequestMapping("/admin/message/{id}")
-  public Message messageById(@PathVariable String id) {
+  public Message adminMessageById(@PathVariable String id) {
     return messagesService.messageById(id);
   }
 }

--- a/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
+++ b/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
@@ -72,17 +72,6 @@ public class MessagesController {
     return statusResponse;
   }
 
-  @Autowired
-  public void setMessagesService(MessagesService messagesService) {
-    this.messagesService = messagesService;
-  }
-
-  @Autowired
-  public void setIsMemberOfHeaderParser(
-    IsMemberOfHeaderParser isMemberOfHeaderParser) {
-    this.isMemberOfHeaderParser = isMemberOfHeaderParser;
-  }
-
   /**
    * Get a specific message regardless of the message's audience, dates, etc.
    *
@@ -92,5 +81,17 @@ public class MessagesController {
   @RequestMapping("/admin/message/{id}")
   public Message adminMessageById(@PathVariable String id) {
     return messagesService.messageById(id);
+  }
+
+
+  @Autowired
+  public void setMessagesService(MessagesService messagesService) {
+    this.messagesService = messagesService;
+  }
+
+  @Autowired
+  public void setIsMemberOfHeaderParser(
+    IsMemberOfHeaderParser isMemberOfHeaderParser) {
+    this.isMemberOfHeaderParser = isMemberOfHeaderParser;
   }
 }

--- a/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
+++ b/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
@@ -89,10 +89,10 @@ public class MessagesController {
   /**
    * Get a specific message, limited by the requesting user's context.
    *
-   * @returns the requested message, or null if none matching
    * @throws PrematureMessageException if the message is not yet gone live
    * @throws ExpiredMessageException if the message is expired
    * @throws UserNotInMessageAudienceException if the requesting user is not in the audience
+   * @returns the requested message, or null if none matching
    */
   @RequestMapping("/message/{id}")
   public Message messageById(@PathVariable String id, HttpServletRequest request)

--- a/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
+++ b/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
@@ -50,7 +50,7 @@ public class MessagesController {
     return responseMap;
   }
 
-  @GetMapping("/allMessages")
+  @GetMapping("/admin/allMessages")
   public Map<String, Object> allMessages() {
     Map<String, Object> responseMap = new HashMap<String, Object>();
     responseMap.put("messages", messagesService.allMessages());

--- a/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
+++ b/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
@@ -1,5 +1,8 @@
 package edu.wisc.my.messages.controller;
 
+import edu.wisc.my.messages.exception.ExpiredMessageException;
+import edu.wisc.my.messages.exception.PrematureMessageException;
+import edu.wisc.my.messages.exception.UserNotInMessageAudienceException;
 import edu.wisc.my.messages.model.Message;
 import edu.wisc.my.messages.model.User;
 import edu.wisc.my.messages.service.MessagesService;
@@ -83,6 +86,27 @@ public class MessagesController {
     return messagesService.messageById(id);
   }
 
+  /**
+   * Get a specific message, limited by the requesting user's context.
+   *
+   * @returns the requested message, or null if none matching
+   * @throws PrematureMessageException if the message is not yet gone live
+   * @throws ExpiredMessageException if the message is expired
+   * @throws UserNotInMessageAudienceException if the requesting user is not in the audience
+   */
+  @RequestMapping("/message/{id}")
+  public Message messageById(@PathVariable String id, HttpServletRequest request)
+    throws UserNotInMessageAudienceException, PrematureMessageException, ExpiredMessageException {
+
+    String isMemberOfHeader = request.getHeader("isMemberOf");
+    Set<String> groups =
+      isMemberOfHeaderParser.groupsFromHeaderValue(isMemberOfHeader);
+    User user = new User();
+    user.setGroups(groups);
+
+    return messagesService.messageByIdForUser(id, user);
+
+  }
 
   @Autowired
   public void setMessagesService(MessagesService messagesService) {

--- a/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
+++ b/src/main/java/edu/wisc/my/messages/controller/MessagesController.java
@@ -1,6 +1,7 @@
 package edu.wisc.my.messages.controller;
 
 import edu.wisc.my.messages.exception.ExpiredMessageException;
+import edu.wisc.my.messages.exception.MessageNotFoundException;
 import edu.wisc.my.messages.exception.PrematureMessageException;
 import edu.wisc.my.messages.exception.UserNotInMessageAudienceException;
 import edu.wisc.my.messages.model.Message;
@@ -82,8 +83,14 @@ public class MessagesController {
    * @return Message with matching ID
    */
   @RequestMapping("/admin/message/{id}")
-  public Message adminMessageById(@PathVariable String id) {
-    return messagesService.messageById(id);
+  public Message adminMessageById(@PathVariable String id) throws MessageNotFoundException {
+
+    Message message = messagesService.messageById(id);
+
+    if (null == message) {
+      throw new MessageNotFoundException();
+    }
+    return message;
   }
 
   /**
@@ -96,7 +103,7 @@ public class MessagesController {
    */
   @RequestMapping("/message/{id}")
   public Message messageById(@PathVariable String id, HttpServletRequest request)
-    throws UserNotInMessageAudienceException, PrematureMessageException, ExpiredMessageException {
+    throws UserNotInMessageAudienceException, PrematureMessageException, ExpiredMessageException, MessageNotFoundException {
 
     String isMemberOfHeader = request.getHeader("isMemberOf");
     Set<String> groups =
@@ -104,8 +111,13 @@ public class MessagesController {
     User user = new User();
     user.setGroups(groups);
 
-    return messagesService.messageByIdForUser(id, user);
+    Message message = messagesService.messageByIdForUser(id, user);
 
+    if (null == message) {
+      throw new MessageNotFoundException();
+    }
+
+    return message;
   }
 
   @Autowired

--- a/src/main/java/edu/wisc/my/messages/exception/ExpiredMessageException.java
+++ b/src/main/java/edu/wisc/my/messages/exception/ExpiredMessageException.java
@@ -18,8 +18,11 @@ public class ExpiredMessageException
   private final LocalDateTime asOfWhen;
 
   public ExpiredMessageException(Message messageWithRequestedId, LocalDateTime asOfWhen) {
-    super("Message with id [" + messageWithRequestedId.getId() + "] is expired as of " + asOfWhen
-      .toString());
+    super("Message " +
+      ((messageWithRequestedId == null) ?
+        "" :
+        (" with id [" + messageWithRequestedId.getId() + "] "))
+      + "is expired as of " + asOfWhen);
     this.expiredMessage = messageWithRequestedId;
     this.asOfWhen = asOfWhen;
   }

--- a/src/main/java/edu/wisc/my/messages/exception/ExpiredMessageException.java
+++ b/src/main/java/edu/wisc/my/messages/exception/ExpiredMessageException.java
@@ -2,7 +2,10 @@ package edu.wisc.my.messages.exception;
 
 import edu.wisc.my.messages.model.Message;
 import java.time.LocalDateTime;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+@ResponseStatus(value = HttpStatus.FORBIDDEN, reason = "Requested message is expired.")
 public class ExpiredMessageException
   extends ForbiddenMessageException {
 

--- a/src/main/java/edu/wisc/my/messages/exception/ExpiredMessageException.java
+++ b/src/main/java/edu/wisc/my/messages/exception/ExpiredMessageException.java
@@ -9,8 +9,8 @@ public class ExpiredMessageException
   private final Message expiredMessage;
 
   /**
-   * Time of consideration. The frame of reference for considering the message expired.
-   * Typically, this is "now".
+   * Time of consideration. The frame of reference for considering the message expired. Typically,
+   * this is "now".
    */
   private final LocalDateTime asOfWhen;
 

--- a/src/main/java/edu/wisc/my/messages/exception/ExpiredMessageException.java
+++ b/src/main/java/edu/wisc/my/messages/exception/ExpiredMessageException.java
@@ -1,0 +1,23 @@
+package edu.wisc.my.messages.exception;
+
+import edu.wisc.my.messages.model.Message;
+import java.time.LocalDateTime;
+
+public class ExpiredMessageException
+  extends ForbiddenMessageException {
+
+  private final Message expiredMessage;
+
+  /**
+   * Time of consideration. The frame of reference for considering the message expired.
+   * Typically, this is "now".
+   */
+  private final LocalDateTime asOfWhen;
+
+  public ExpiredMessageException(Message messageWithRequestedId, LocalDateTime asOfWhen) {
+    super("Message with id [" + messageWithRequestedId.getId() + "] is expired as of " + asOfWhen
+      .toString());
+    this.expiredMessage = messageWithRequestedId;
+    this.asOfWhen = asOfWhen;
+  }
+}

--- a/src/main/java/edu/wisc/my/messages/exception/ForbiddenMessageException.java
+++ b/src/main/java/edu/wisc/my/messages/exception/ForbiddenMessageException.java
@@ -1,0 +1,13 @@
+package edu.wisc.my.messages.exception;
+
+/**
+ * Message representing that access to a requested message is forbidden.
+ * Sub-classes represent specific reasons why access might be forbidden.
+ */
+public class ForbiddenMessageException
+  extends Exception {
+
+  public ForbiddenMessageException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/edu/wisc/my/messages/exception/ForbiddenMessageException.java
+++ b/src/main/java/edu/wisc/my/messages/exception/ForbiddenMessageException.java
@@ -1,8 +1,8 @@
 package edu.wisc.my.messages.exception;
 
 /**
- * Message representing that access to a requested message is forbidden.
- * Sub-classes represent specific reasons why access might be forbidden.
+ * Message representing that access to a requested message is forbidden. Sub-classes represent
+ * specific reasons why access might be forbidden.
  */
 public class ForbiddenMessageException
   extends Exception {

--- a/src/main/java/edu/wisc/my/messages/exception/ForbiddenMessageException.java
+++ b/src/main/java/edu/wisc/my/messages/exception/ForbiddenMessageException.java
@@ -1,9 +1,13 @@
 package edu.wisc.my.messages.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
 /**
  * Message representing that access to a requested message is forbidden. Sub-classes represent
  * specific reasons why access might be forbidden.
  */
+@ResponseStatus(value = HttpStatus.FORBIDDEN, reason = "Access denied to requested message.")
 public class ForbiddenMessageException
   extends Exception {
 

--- a/src/main/java/edu/wisc/my/messages/exception/MessageNotFoundException.java
+++ b/src/main/java/edu/wisc/my/messages/exception/MessageNotFoundException.java
@@ -1,0 +1,13 @@
+package edu.wisc.my.messages.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Represents case where requested message was not found.
+ */
+@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "Did not find requested message.")
+public class MessageNotFoundException
+  extends Exception {
+
+}

--- a/src/main/java/edu/wisc/my/messages/exception/PrematureMessageException.java
+++ b/src/main/java/edu/wisc/my/messages/exception/PrematureMessageException.java
@@ -16,10 +16,12 @@ public class PrematureMessageException
   private LocalDateTime asOfWhen;
 
   public PrematureMessageException(Message prematureMessage, LocalDateTime asOfWhen) {
-    super("Message with id " + prematureMessage.getId() + " is premature as of "
-      + asOfWhen.toString());
+    super("Message with id " +
+      ((null == prematureMessage) ?
+        "" :
+        prematureMessage.getId() + " ")
+      + "is premature as of " + asOfWhen);
     this.prematureMessage = prematureMessage;
     this.asOfWhen = asOfWhen;
   }
-
 }

--- a/src/main/java/edu/wisc/my/messages/exception/PrematureMessageException.java
+++ b/src/main/java/edu/wisc/my/messages/exception/PrematureMessageException.java
@@ -1,0 +1,22 @@
+package edu.wisc.my.messages.exception;
+
+import edu.wisc.my.messages.model.Message;
+import java.time.LocalDateTime;
+
+/**
+ * Thrown on un-privileged request for a message that has not yet gone live.
+ */
+public class PrematureMessageException
+  extends ForbiddenMessageException {
+
+  private Message prematureMessage;
+  private LocalDateTime asOfWhen;
+
+  public PrematureMessageException(Message prematureMessage, LocalDateTime asOfWhen) {
+    super("Message with id " + prematureMessage.getId() + " is premature as of "
+      + asOfWhen.toString());
+    this.prematureMessage = prematureMessage;
+    this.asOfWhen = asOfWhen;
+  }
+
+}

--- a/src/main/java/edu/wisc/my/messages/exception/PrematureMessageException.java
+++ b/src/main/java/edu/wisc/my/messages/exception/PrematureMessageException.java
@@ -2,10 +2,13 @@ package edu.wisc.my.messages.exception;
 
 import edu.wisc.my.messages.model.Message;
 import java.time.LocalDateTime;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 /**
  * Thrown on un-privileged request for a message that has not yet gone live.
  */
+@ResponseStatus(value = HttpStatus.FORBIDDEN, reason = "Requested message is premature.")
 public class PrematureMessageException
   extends ForbiddenMessageException {
 

--- a/src/main/java/edu/wisc/my/messages/exception/UserNotInMessageAudienceException.java
+++ b/src/main/java/edu/wisc/my/messages/exception/UserNotInMessageAudienceException.java
@@ -1,0 +1,16 @@
+package edu.wisc.my.messages.exception;
+
+import edu.wisc.my.messages.model.Message;
+import edu.wisc.my.messages.model.User;
+
+public class UserNotInMessageAudienceException extends ForbiddenMessageException {
+
+  private final Message messageNotForUser;
+  private final User userNotInMessageAudience;
+
+  public UserNotInMessageAudienceException(Message message, User user) {
+    super("User not within audience of requested message");
+    this.messageNotForUser = message;
+    this.userNotInMessageAudience = user;
+  }
+}

--- a/src/main/java/edu/wisc/my/messages/exception/UserNotInMessageAudienceException.java
+++ b/src/main/java/edu/wisc/my/messages/exception/UserNotInMessageAudienceException.java
@@ -2,7 +2,10 @@ package edu.wisc.my.messages.exception;
 
 import edu.wisc.my.messages.model.Message;
 import edu.wisc.my.messages.model.User;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+@ResponseStatus(value = HttpStatus.FORBIDDEN, reason = "Requesting user not in audience for requested message")
 public class UserNotInMessageAudienceException extends ForbiddenMessageException {
 
   private final Message messageNotForUser;

--- a/src/main/java/edu/wisc/my/messages/service/MessageIdPredicate.java
+++ b/src/main/java/edu/wisc/my/messages/service/MessageIdPredicate.java
@@ -1,0 +1,35 @@
+package edu.wisc.my.messages.service;
+
+import edu.wisc.my.messages.model.Message;
+import java.util.Objects;
+import java.util.function.Predicate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Predicate that is true where the tested message has a (potentially null) ID matching that
+ * (potentially null) ID given at construction.
+ */
+public class MessageIdPredicate
+  implements Predicate<Message> {
+
+  private final String idToMatch;
+  protected Logger logger = LoggerFactory.getLogger(getClass());
+
+  /**
+   * Instantiate a MessageIdPredicate that tests for a specific ID.
+   *
+   * @param idToMatch potentially null message identifier to look for
+   */
+  public MessageIdPredicate(String idToMatch) {
+    this.idToMatch = idToMatch;
+  }
+
+  @Override
+  public boolean test(Message message) {
+    boolean result = (null != message
+      && Objects.equals(this.idToMatch, message.getId()));
+    logger.trace("{} result testing for id {} in message {}", result, idToMatch, message);
+    return result;
+  }
+}

--- a/src/main/java/edu/wisc/my/messages/service/MessagesService.java
+++ b/src/main/java/edu/wisc/my/messages/service/MessagesService.java
@@ -40,6 +40,8 @@ public class MessagesService {
     validMessages.addAll(messageSource.allMessages());
     validMessages.removeIf(retainMessage.negate()); // remove the messages we're not retaining
 
+    logger.trace("Found {} messages for user {}.", validMessages.size(), user);
+
     return validMessages;
   }
 

--- a/src/main/resources/messages.json
+++ b/src/main/resources/messages.json
@@ -304,6 +304,62 @@
         "label": "More info"
       },
       "confirmButton": null
+    },
+    {
+      "id": "premature",
+      "title": "An announcement before its time.",
+      "titleShort": "Not yet gone live.",
+      "description": "This announcement is not live. Too soon..",
+      "descriptionShort": "Premature.",
+      "messageType": "announcement",
+      "featureImageUrl": null,
+      "priority": null,
+      "filter": {
+        "goLiveDate": "2999-01-01",
+        "expireDate": null
+      },
+      "data": {
+        "dataUrl": null,
+        "dataObject": null,
+        "dataArrayFilter": null
+      },
+      "actionButton": {
+        "label": "Call to action",
+        "url": "http://www.example.edu"
+      },
+      "moreInfoButton": {
+        "url": "https://www.apereo.org/content/2018-open-apereo-montreal-quebec",
+        "label": "More info"
+      },
+      "confirmButton": null
+    },
+    {
+      "id": "expired",
+      "title": "An announcement after its time",
+      "titleShort": "Expired.",
+      "description": "This announcement is not live. Too late.",
+      "descriptionShort": "Expired.",
+      "messageType": "announcement",
+      "featureImageUrl": null,
+      "priority": null,
+      "filter": {
+        "goLiveDate": null,
+        "expireDate": "2000-01-01"
+      },
+      "data": {
+        "dataUrl": null,
+        "dataObject": null,
+        "dataArrayFilter": null
+      },
+      "actionButton": {
+        "label": "Call to action",
+        "url": "http://www.example.edu"
+      },
+      "moreInfoButton": {
+        "url": "https://www.apereo.org/content/2018-open-apereo-montreal-quebec",
+        "label": "More info"
+      },
+      "confirmButton": null
     }
   ]
 }

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
@@ -94,7 +94,8 @@ public class MessagesControllerTest {
   /**
    * Test that looking for a message by an ID that does not match yields a 404 NOT FOUND.
    */
-  public void notFoundMessageYields404() throws Exception {
+  @Test
+  public void adminNotFoundMessageYields404() throws Exception {
     mvc.perform(MockMvcRequestBuilders.get("/admin/message/no-such-message")
       .accept(MediaType.APPLICATION_JSON))
       .andExpect(status().isNotFound());

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
@@ -41,4 +41,62 @@ public class MessagesControllerTest {
   public void dataIsValid() {
     this.messageReader.allMessages();
   }
+
+
+  /**
+   * Test the /admin/message/{id} path reading a message.
+   *
+   * @throws Exception as an unexpected test failure modality
+   */
+  @Test
+  public void messageById() throws Exception {
+    String expectedJson = "{\n"
+      + "  \"id\": \"demo-high-priority-valid-group-no-date\",\n"
+      + "  \"title\": \"Valid group. No date. High priority.\",\n"
+      + "  \"titleShort\": \"Valid group. No date. High priority.\",\n"
+      + "  \"titleUrl\": null,\n"
+      + "  \"description\": \"Valid group. No date. High priority.\",\n"
+      + "  \"descriptionShort\": \"Valid group. No date. High priority.\",\n"
+      + "  \"messageType\": \"notification\",\n"
+      + "  \"featureImageUrl\": null,\n"
+      + "  \"priority\": \"high\",\n"
+      + "  \"recurrence\": null,\n"
+      + "  \"dismissible\": null,\n"
+      + "  \"filter\": {\n"
+      + "    \"goLiveDate\": null,\n"
+      + "    \"expireDate\": null,\n"
+      + "    \"groups\": [\n"
+      + "      \"Portal Administrators\"\n"
+      + "    ]\n"
+      + "  },\n"
+      + "  \"data\": {\n"
+      + "    \"dataUrl\": null,\n"
+      + "    \"dataObject\": null,\n"
+      + "    \"dataArrayFilter\": null,\n"
+      + "    \"dataMessageTitle\": null,\n"
+      + "    \"dataMessageMoreInfoUrl\": null\n"
+      + "  },\n"
+      + "  \"actionButton\": {\n"
+      + "    \"label\": \"Go\",\n"
+      + "    \"url\": \"http://www.google.com\"\n"
+      + "  },\n"
+      + "  \"moreInfoButton\": null,\n"
+      + "  \"confirmButton\": null\n"
+      + "}";
+
+    mvc.perform(MockMvcRequestBuilders.get("/admin/message/demo-high-priority-valid-group-no-date")
+      .accept(MediaType.APPLICATION_JSON))
+      .andExpect(status().isOk())
+      .andExpect(content().contentTypeCompatibleWith("application/json"))
+      .andExpect(content().json(expectedJson));
+  }
+
+  /**
+   * Test that looking for a message by an ID that does not match yields a 404 NOT FOUND.
+   */
+  public void notFoundMessageYields404() throws Exception {
+    mvc.perform(MockMvcRequestBuilders.get("/admin/message/no-such-message")
+      .accept(MediaType.APPLICATION_JSON))
+      .andExpect(status().isNotFound());
+  }
 }

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
@@ -146,7 +146,7 @@ public class MessagesControllerTest {
   }
 
   /**
-   * Attempting to get a message you are not in the audience of yields 5xx error.
+   * Attempting to get a message you are not in the audience of yields 403 FORBIDDEN.
    */
   @Test
   public void notInAudienceMessageByIdYieldsError() throws Exception {
@@ -156,7 +156,7 @@ public class MessagesControllerTest {
   }
 
   /**
-   * Attempting to get an expired message yields 5xx error.
+   * Attempting to get an expired message yields 403 FORBIDDEN.
    */
   @Test
   public void expiredMessageByIdYieldsError() throws Exception {
@@ -166,7 +166,7 @@ public class MessagesControllerTest {
   }
 
   /**
-   * Attempting to get premature message yields 5xx error.
+   * Attempting to get premature message yields 403 FORBIDDEN.
    */
   @Test
   public void prematureMessageByIdYieldsError() throws Exception {

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
@@ -49,7 +49,7 @@ public class MessagesControllerTest {
    * @throws Exception as an unexpected test failure modality
    */
   @Test
-  public void messageById() throws Exception {
+  public void adminMessageById() throws Exception {
     String expectedJson = "{\n"
       + "  \"id\": \"demo-high-priority-valid-group-no-date\",\n"
       + "  \"title\": \"Valid group. No date. High priority.\",\n"
@@ -98,5 +98,80 @@ public class MessagesControllerTest {
     mvc.perform(MockMvcRequestBuilders.get("/admin/message/no-such-message")
       .accept(MediaType.APPLICATION_JSON))
       .andExpect(status().isNotFound());
+  }
+
+  /**
+   * Test the /admin/message/{id} path reading a message.
+   *
+   * @throws Exception as an unexpected test failure modality
+   */
+  @Test
+  public void messageById() throws Exception {
+    String expectedJson = "{\n"
+      + "  \"id\": \"has-no-audience-filter\",\n"
+      + "  \"title\": \"An announcement lacking an audience filter.\",\n"
+      + "  \"titleShort\": \"Not filtered by audience\",\n"
+      + "  \"titleUrl\": null,\n"
+      + "  \"description\": \"This announcement is not filtered by groups.\",\n"
+      + "  \"descriptionShort\": \"Not filtered by groups.\",\n"
+      + "  \"messageType\": \"announcement\",\n"
+      + "  \"featureImageUrl\": null,\n"
+      + "  \"priority\": null,\n"
+      + "  \"recurrence\": null,\n"
+      + "  \"dismissible\": null,\n"
+      + "  \"filter\": null,\n"
+      + "  \"data\": {\n"
+      + "    \"dataUrl\": null,\n"
+      + "    \"dataObject\": null,\n"
+      + "    \"dataArrayFilter\": null,\n"
+      + "    \"dataMessageTitle\": null,\n"
+      + "    \"dataMessageMoreInfoUrl\": null\n"
+      + "  },\n"
+      + "  \"actionButton\": {\n"
+      + "    \"label\": \"Add to home\",\n"
+      + "    \"url\": \"addToHome/open-apereo\"\n"
+      + "  },\n"
+      + "  \"moreInfoButton\": {\n"
+      + "    \"label\": \"More info\",\n"
+      + "    \"url\": \"https://www.apereo.org/content/2018-open-apereo-montreal-quebec\"\n"
+      + "  },\n"
+      + "  \"confirmButton\": null\n"
+      + "}";
+
+    mvc.perform(MockMvcRequestBuilders.get("/message/has-no-audience-filter")
+      .accept(MediaType.APPLICATION_JSON))
+      .andExpect(status().isOk())
+      .andExpect(content().contentTypeCompatibleWith("application/json"))
+      .andExpect(content().json(expectedJson));
+  }
+
+  /**
+   * Attempting to get a message you are not in the audience of yields 5xx error.
+   */
+  @Test
+  public void notInAudienceMessageByIdYieldsError() throws Exception {
+    mvc.perform(MockMvcRequestBuilders.get("/message/1")
+      .accept(MediaType.APPLICATION_JSON))
+      .andExpect(status().isForbidden());
+  }
+
+  /**
+   * Attempting to get an expired message yields 5xx error.
+   */
+  @Test
+  public void expiredMessageByIdYieldsError() throws Exception {
+    mvc.perform(MockMvcRequestBuilders.get("/message/expired")
+      .accept(MediaType.APPLICATION_JSON))
+      .andExpect(status().isForbidden());
+  }
+
+  /**
+   * Attempting to get premature message yields 5xx error.
+   */
+  @Test
+  public void prematureMessageByIdYieldsError() throws Exception {
+    mvc.perform(MockMvcRequestBuilders.get("/message/premature")
+      .accept(MediaType.APPLICATION_JSON))
+      .andExpect(status().isForbidden());
   }
 }

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
@@ -175,4 +175,14 @@ public class MessagesControllerTest {
       .accept(MediaType.APPLICATION_JSON))
       .andExpect(status().isForbidden());
   }
+
+  /**
+   * Test that looking for a message by an ID that does not match yields a 404 NOT FOUND.
+   */
+  @Test
+  public void notFoundMessageYields404() throws Exception {
+    mvc.perform(MockMvcRequestBuilders.get("/admin/message/no-such-message")
+      .accept(MediaType.APPLICATION_JSON))
+      .andExpect(status().isNotFound());
+  }
 }

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import edu.wisc.my.messages.exception.ForbiddenMessageException;
+import edu.wisc.my.messages.exception.MessageNotFoundException;
 import edu.wisc.my.messages.model.Message;
 import edu.wisc.my.messages.model.User;
 import edu.wisc.my.messages.service.MessagesService;
@@ -105,7 +106,7 @@ public class MessagesControllerUnitTest {
   }
 
   @Test
-  public void passesSpecificMessageToView() {
+  public void passesSpecificMessageToView() throws MessageNotFoundException {
     MessagesService mockService = mock(MessagesService.class);
 
     MessagesController controller = new MessagesController();
@@ -121,9 +122,22 @@ public class MessagesControllerUnitTest {
     assertEquals(matchingMessage, result);
   }
 
+  @Test(expected = MessageNotFoundException.class)
+  public void throwsNotFoundExceptionWhenNoMessageByIdAdmin()
+    throws ForbiddenMessageException, MessageNotFoundException {
+    MessagesService mockService = mock(MessagesService.class);
+
+    MessagesController controller = new MessagesController();
+    controller.setMessagesService(mockService);
+
+    when(mockService.messageByIdForUser(eq("some-id"), any())).thenReturn(null);
+
+    Message resultMessage = controller.adminMessageById("some-id");
+  }
+
   @Test
   public void passesSpecificMessageToViewForUser()
-    throws ForbiddenMessageException {
+    throws ForbiddenMessageException, MessageNotFoundException {
     MessagesService mockService = mock(MessagesService.class);
     IsMemberOfHeaderParser mockParser = mock(IsMemberOfHeaderParser.class);
 
@@ -141,6 +155,23 @@ public class MessagesControllerUnitTest {
     Message resultMessage = controller.messageById("some-id", mockRequest);
 
     assertEquals(matchingMessage, resultMessage);
+  }
+
+  @Test(expected = MessageNotFoundException.class)
+  public void throwsNotFoundExceptionWhenNoMessageById()
+    throws ForbiddenMessageException, MessageNotFoundException {
+    MessagesService mockService = mock(MessagesService.class);
+    IsMemberOfHeaderParser mockParser = mock(IsMemberOfHeaderParser.class);
+
+    MessagesController controller = new MessagesController();
+    controller.setMessagesService(mockService);
+    controller.setIsMemberOfHeaderParser(mockParser);
+
+    when(mockService.messageByIdForUser(eq("some-id"), any())).thenReturn(null);
+
+    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+
+    Message resultMessage = controller.messageById("some-id", mockRequest);
   }
 
 }

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
@@ -104,4 +104,25 @@ public class MessagesControllerUnitTest {
     assertSame(messages, result.get("messages"));
   }
 
+  @Test
+  public void passesSpecificMessageToView() {
+    MessagesService mockService = mock(MessagesService.class);
+
+    MessagesController controller = new MessagesController();
+    controller.setMessagesService(mockService);
+
+    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+
+    List<Message> messages = new ArrayList<>();
+
+    Message matchingMessage = new Message();
+    matchingMessage.setId("some-id");
+
+    when(mockService.messageById("some-id")).thenReturn(matchingMessage);
+
+    Message result = controller.messageById("some-id");
+
+    assertEquals(matchingMessage, result);
+  }
+
 }

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
@@ -124,5 +124,4 @@ public class MessagesControllerUnitTest {
 
     assertEquals(matchingMessage, result);
   }
-
 }

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
@@ -2,12 +2,14 @@ package edu.wisc.my.messages.controller;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import edu.wisc.my.messages.exception.ForbiddenMessageException;
 import edu.wisc.my.messages.model.Message;
 import edu.wisc.my.messages.model.User;
 import edu.wisc.my.messages.service.MessagesService;
@@ -118,4 +120,27 @@ public class MessagesControllerUnitTest {
 
     assertEquals(matchingMessage, result);
   }
+
+  @Test
+  public void passesSpecificMessageToViewForUser()
+    throws ForbiddenMessageException {
+    MessagesService mockService = mock(MessagesService.class);
+    IsMemberOfHeaderParser mockParser = mock(IsMemberOfHeaderParser.class);
+
+    MessagesController controller = new MessagesController();
+    controller.setMessagesService(mockService);
+    controller.setIsMemberOfHeaderParser(mockParser);
+
+    Message matchingMessage = new Message();
+    matchingMessage.setId("some-id");
+
+    when(mockService.messageByIdForUser(eq("some-id"), any())).thenReturn(matchingMessage);
+
+    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+
+    Message resultMessage = controller.messageById("some-id", mockRequest);
+
+    assertEquals(matchingMessage, resultMessage);
+  }
+
 }

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
@@ -114,7 +114,7 @@ public class MessagesControllerUnitTest {
 
     when(mockService.messageById("some-id")).thenReturn(matchingMessage);
 
-    Message result = controller.messageById("some-id");
+    Message result = controller.adminMessageById("some-id");
 
     assertEquals(matchingMessage, result);
   }

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerUnitTest.java
@@ -93,8 +93,6 @@ public class MessagesControllerUnitTest {
     MessagesController controller = new MessagesController();
     controller.setMessagesService(mockService);
 
-    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
-
     List<Message> messages = new ArrayList<>();
 
     when(mockService.allMessages()).thenReturn(messages);
@@ -110,10 +108,6 @@ public class MessagesControllerUnitTest {
 
     MessagesController controller = new MessagesController();
     controller.setMessagesService(mockService);
-
-    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
-
-    List<Message> messages = new ArrayList<>();
 
     Message matchingMessage = new Message();
     matchingMessage.setId("some-id");

--- a/src/test/java/edu/wisc/my/messages/exception/ExpiredMessageExceptionTest.java
+++ b/src/test/java/edu/wisc/my/messages/exception/ExpiredMessageExceptionTest.java
@@ -1,0 +1,12 @@
+package edu.wisc.my.messages.exception;
+
+import org.junit.Test;
+
+public class ExpiredMessageExceptionTest {
+
+  @Test
+  public void copesWithNullConstructorArguments() {
+    new ExpiredMessageException(null, null);
+  }
+
+}

--- a/src/test/java/edu/wisc/my/messages/exception/PrematureMessageExceptionTest.java
+++ b/src/test/java/edu/wisc/my/messages/exception/PrematureMessageExceptionTest.java
@@ -1,0 +1,12 @@
+package edu.wisc.my.messages.exception;
+
+import org.junit.Test;
+
+public class PrematureMessageExceptionTest {
+
+  @Test
+  public void copesWithNullConstructorArguments() {
+    new PrematureMessageException(null, null);
+  }
+
+}

--- a/src/test/java/edu/wisc/my/messages/service/MessageIdPredicateTest.java
+++ b/src/test/java/edu/wisc/my/messages/service/MessageIdPredicateTest.java
@@ -1,0 +1,69 @@
+package edu.wisc.my.messages.service;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import edu.wisc.my.messages.model.Message;
+import org.junit.Test;
+
+public class MessageIdPredicateTest {
+
+  @Test
+  public void nullMessageTestsFalse() {
+    MessageIdPredicate predicate = new MessageIdPredicate("does-not-matter");
+    assertFalse(predicate.test(null));
+  }
+
+  @Test
+  public void mismatchIdTestsFalse() {
+    MessageIdPredicate predicate = new MessageIdPredicate("a-particular-id");
+    Message message = new Message();
+    message.setId("not-that-particular-id");
+
+    assertFalse(predicate.test(message));
+  }
+
+  @Test
+  public void matchingIdTestsTrue() {
+    MessageIdPredicate predicate = new MessageIdPredicate("a-particular-id");
+    Message message = new Message();
+    message.setId("a-particular-id");
+
+    assertTrue(predicate.test(message));
+  }
+
+  @Test
+  public void matchingNullIdTestsTrue() {
+    MessageIdPredicate predicate = new MessageIdPredicate(null);
+    Message messageWithNullId = new Message();
+
+    assertTrue(predicate.test(messageWithNullId));
+  }
+
+
+  /**
+   * Test that testing a message with a non-null id for a null message ID evaluates correctly false
+   * and does not NullPointer out.
+   */
+  @Test
+  public void notMatchingPredicateLookingForNullTestsFalse() {
+    MessageIdPredicate messageHasNullIdPredicate = new MessageIdPredicate(null);
+    Message messageWithNonNullId = new Message();
+    messageWithNonNullId.setId("not-null-id");
+
+    assertFalse(messageHasNullIdPredicate.test(messageWithNonNullId));
+  }
+
+  /**
+   * Test that testing a message with a null id for a non-null message ID evaluates correctly false
+   * and does not NullPointer out.
+   */
+  @Test
+  public void nullMessageIdNotMatchingPredicateLookingForNonNullTestsFalse() {
+    MessageIdPredicate someMessageIdPredicate = new MessageIdPredicate("some-id");
+    Message messageWithNullId = new Message();
+
+    assertFalse(someMessageIdPredicate.test(messageWithNullId));
+  }
+
+}

--- a/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
+++ b/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
@@ -2,6 +2,7 @@ package edu.wisc.my.messages.service;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -163,6 +164,85 @@ public class MessagesServiceTest {
     assertNotNull(result);
 
     assertEquals(2, result.size());
+  }
+
+  /**
+   * Test that returns the message matching a given ID.
+   */
+  @Test
+  public void returnsMessageMatchingId() {
+    MessagesService service = new MessagesService();
+
+    Message firstMessage = new Message();
+    firstMessage.setId("uniqueMessageId-1");
+
+    Message secondMessage = new Message();
+    secondMessage.setId("anotherMessageId-2");
+
+    List<Message> messagesFromRepository = new ArrayList<>();
+    messagesFromRepository.add(firstMessage);
+    messagesFromRepository.add(secondMessage);
+
+    MessagesFromTextFile messageSource = mock(MessagesFromTextFile.class);
+    when(messageSource.allMessages()).thenReturn(messagesFromRepository);
+
+    service.setMessageSource(messageSource);
+
+    Message result = service.messageById("uniqueMessageId-1");
+
+    assertEquals(firstMessage, result);
+  }
+
+  @Test
+  public void returnsNullWhenNoMatchingId() {
+    MessagesService service = new MessagesService();
+
+    Message firstMessage = new Message();
+    firstMessage.setId("uniqueMessageId-1");
+
+    Message secondMessage = new Message();
+    secondMessage.setId("anotherMessageId-2");
+
+    List<Message> messagesFromRepository = new ArrayList<>();
+    messagesFromRepository.add(firstMessage);
+    messagesFromRepository.add(secondMessage);
+
+    MessagesFromTextFile messageSource = mock(MessagesFromTextFile.class);
+    when(messageSource.allMessages()).thenReturn(messagesFromRepository);
+
+    service.setMessageSource(messageSource);
+
+    Message result = service.messageById("no-message-with-this-id");
+
+    assertNull(result);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void throwsIllegalStateExceptionWhenMultipleMessagesMatchId() {
+    MessagesService service = new MessagesService();
+
+    Message firstMessage = new Message();
+    firstMessage.setId("not-so-unique-id");
+
+    Message secondMessage = new Message();
+    secondMessage.setId("not-so-unique-id");
+
+    List<Message> messagesFromRepository = new ArrayList<>();
+    messagesFromRepository.add(firstMessage);
+    messagesFromRepository.add(secondMessage);
+
+    MessagesFromTextFile messageSource = mock(MessagesFromTextFile.class);
+    when(messageSource.allMessages()).thenReturn(messagesFromRepository);
+
+    service.setMessageSource(messageSource);
+
+    Message result = service.messageById("not-so-unique-id");
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void requestingMessageWithNullIdThrowsNPE() {
+    MessagesService service = new MessagesService();
+    service.messageById(null);
   }
 
 }


### PR DESCRIPTION
Adds paths for viewing just one message, identified by id.

 + `/admin/message/{id}` will view the message regardless of audience
+ `/message/{id}` will view the message iff the message is available in the context of the request (so, considering who is asking, current date vs begin and end dates, etc.)

Why? To bootstrap idiomatic error handling in this Spring Boot microservice, namely
+ trying to view a non-existent id should yield `404 NOT FOUND`
+ non-administratively trying to view a message you're not in the audience for should yield `403 FORBIDDEN`

What this demonstrates:

+ ~~Controller returning `null` automagically is `404 NOT FOUND`.~~ (Not true! Moral of story is always ensure your unit test fails before it succeeds, otherwise maybe you forgot to `@Test` annotate, as I did.)
+ Controller throwing automagically is `500` unless the exception is annotated (as the custom exceptions here are), then it's whatever the annotation said (here, `403 FORBIDDEN` or `404 NOT FOUND`).
+ Domain exceptions can be generated down in the Service layer and beyond where they're really happening, let them percolate up out through the Controller, it's all good.

```
@ResponseStatus(value = HttpStatus.FORBIDDEN, 
  reason = "Requesting user not in audience for requested message")
public class UserNotInMessageAudienceException extends RuntimeException {
```
 ## Tradeoffs navigated

Explored *not* using Exceptions to model errors out of the `Controller` layer. That wasn't much fun. SpringWebMVC really "wants" to use annotated Exceptions for this.

----
Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements

----

[Definition of Done][]

<!-- Intended as a low-intrusion quick checklist reminder of Definition of Done.
     Routinely, take the opportunity to reflect and then tick off the did-the-right-thing-for items.
     Exceptionally, explain what's exceptional why.
-->

- [x] Documented
- [x] Fails gracefully
- [x] Tested
- [x] Secure
- [x] Adds no defects
- [x] Shippable. Path is clear to promote to production
- [x] Maintainable
- [x] Configurable
- [x] Readable
- [x] Validates and sanitizes user input
- [x] Styled (Google Style)

[Definition of Done]: https://goo.gl/4JG2Z5
