### PR TITLE
fix: support not-filtered-at-all messages

### DIFF
--- a/src/main/java/edu/wisc/my/messages/model/Message.java
+++ b/src/main/java/edu/wisc/my/messages/model/Message.java
@@ -323,8 +323,8 @@ public class Message {
   @Override
   public int hashCode() {
     return Objects
-      .hash(id, title, titleShort, description, descriptionShort, titleUrl, messageType, 
-      featureImageUrl, priority, recurrence, dismissible, filter, data,
+      .hash(id, title, titleShort, description, descriptionShort, titleUrl, messageType,
+        featureImageUrl, priority, recurrence, dismissible, filter, data,
         actionButton, moreInfoButton, confirmButton);
   }
 

--- a/src/main/java/edu/wisc/my/messages/model/MessageFilter.java
+++ b/src/main/java/edu/wisc/my/messages/model/MessageFilter.java
@@ -32,7 +32,7 @@ public class MessageFilter
   }
 
   public MessageFilter addGroupsItem(String groupsItem) {
-    if(null == this.groups) {
+    if (null == this.groups) {
       this.groups = new ArrayList<String>();
     }
     this.groups.add(groupsItem);
@@ -109,11 +109,11 @@ public class MessageFilter
     // audience - HOWEVER - if there is an array of groups, and that array
     // is empty, then a filter was specified and the creator of this message
     // intended to specify showing this message to no groups.
-    if(null == this.groups) {
+    if (null == this.groups) {
       return true;
     }
 
-    if(this.groups.size() == 0) {
+    if (this.groups.size() == 0) {
       return false;
     }
 

--- a/src/main/java/edu/wisc/my/messages/model/MessageFilter.java
+++ b/src/main/java/edu/wisc/my/messages/model/MessageFilter.java
@@ -19,7 +19,7 @@ public class MessageFilter
 
   @JsonProperty("goLiveDate")
   private String goLiveDate = null;
-  
+
   @JsonProperty("expireDate")
   private String expireDate = null;
 
@@ -116,7 +116,7 @@ public class MessageFilter
     if(this.groups.size() == 0) {
       return false;
     }
-    
+
     Set<String> requireAtLeastOneOfTheseGroups = new HashSet<>();
     requireAtLeastOneOfTheseGroups.addAll(this.groups);
     requireAtLeastOneOfTheseGroups.retainAll(user.getGroups());

--- a/src/main/java/edu/wisc/my/messages/model/MessageFilter.java
+++ b/src/main/java/edu/wisc/my/messages/model/MessageFilter.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * Predicate over User, answering whether the User is or is not in the Audience. <p> Currently
@@ -73,33 +74,24 @@ public class MessageFilter
       return false;
     }
     MessageFilter audienceFilter = (MessageFilter) o;
-    return Objects.equals(this.groups, audienceFilter.groups);
+
+    return Objects.deepEquals(this.groups, audienceFilter.groups)
+      && Objects.equals(this.goLiveDate, audienceFilter.goLiveDate)
+      && Objects.equals(this.expireDate, audienceFilter.expireDate);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(groups);
+    return Objects.hash(groups, goLiveDate, expireDate);
   }
 
   @Override
   public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class AudienceFilter {\n");
-
-    sb.append("    groups: ").append(toIndentedString(groups)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces (except the first
-   * line).
-   */
-  private String toIndentedString(java.lang.Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
+    return new ToStringBuilder(this)
+      .append("groups", groups)
+      .append("goLiveDate", goLiveDate)
+      .append("expireDate", expireDate)
+      .toString();
   }
 
   @Override

--- a/src/main/java/edu/wisc/my/messages/service/AudienceFilterMessagePredicate.java
+++ b/src/main/java/edu/wisc/my/messages/service/AudienceFilterMessagePredicate.java
@@ -1,7 +1,7 @@
 package edu.wisc.my.messages.service;
 
-import edu.wisc.my.messages.model.MessageFilter;
 import edu.wisc.my.messages.model.Message;
+import edu.wisc.my.messages.model.MessageFilter;
 import edu.wisc.my.messages.model.User;
 import java.util.function.Predicate;
 import org.apache.commons.lang3.Validate;

--- a/src/main/java/edu/wisc/my/messages/service/ExpiredMessagePredicate.java
+++ b/src/main/java/edu/wisc/my/messages/service/ExpiredMessagePredicate.java
@@ -9,7 +9,8 @@ import org.apache.commons.lang3.Validate;
 
 /**
  * Predicate that is true for messages that are expired (or cannot be verified as not expired due to
- * bogus expiration data.) False otherwise. Throws RuntimeException on evaluating null message.
+ * bogus expiration data.) False otherwise. False for messages with no filter (and thus no
+ * expiration date). Throws RuntimeException on evaluating null message.
  */
 public class ExpiredMessagePredicate
   implements Predicate<Message> {
@@ -29,7 +30,8 @@ public class ExpiredMessagePredicate
 
     try {
       MessageFilter filter = message.getFilter();
-      return beforeWhen.test(filter.getExpireDate());
+      return (null != filter
+        && beforeWhen.test(filter.getExpireDate()));
     } catch (Exception e) {
       return true;
     }

--- a/src/main/java/edu/wisc/my/messages/service/GoneLiveMessagePredicate.java
+++ b/src/main/java/edu/wisc/my/messages/service/GoneLiveMessagePredicate.java
@@ -8,8 +8,9 @@ import org.apache.commons.lang3.Validate;
 
 /**
  * Predicate that is true for messages that have gone live, either because they have no goLiveDate
- * or because their goLiveDate is before the date of comparison as given in the constructor.
- * Messages with unparseable go live dates have not gone live.
+ * or no filter that might contain a goLiveDate or because their goLiveDate is before the date of
+ * comparison as given in the constructor. Messages with unparseable go live dates have not gone
+ * live.
  */
 public class GoneLiveMessagePredicate
   implements Predicate<Message> {
@@ -28,7 +29,8 @@ public class GoneLiveMessagePredicate
     IsoDateTimeStringAfterPredicate afterWhen = new IsoDateTimeStringAfterPredicate(when);
 
     try {
-      return (!afterWhen.test(message.getFilter().getGoLiveDate()));
+      return ((null == message.getFilter())
+        || (!afterWhen.test(message.getFilter().getGoLiveDate())));
     } catch (Exception e) {
       return false;
     }

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
@@ -1,9 +1,12 @@
 package edu.wisc.my.messages.controller;
 
+import static org.junit.Assert.assertEquals;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import edu.wisc.my.messages.data.MessagesFromTextFile;
+import edu.wisc.my.messages.model.Message;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +27,9 @@ public class MessagesControllerTest {
 
   @Autowired
   private MockMvc mvc;
+
+  @Autowired
+  private MessagesFromTextFile messageReader;
 
   @Test
   public void siteIsUp() throws Exception {
@@ -51,6 +57,12 @@ public class MessagesControllerTest {
     messageReader.setEnv(mockEnv);
     messageReader.setResourceLoader(defaultLoader);
 
-    messageReader.allMessages();
+    List<Message> allMessages = messageReader.allMessages();
+
+    // use the Spring injected wired up MessageReader
+    List<Message> anotherAllMessages = this.messageReader.allMessages();
+
+    // assert that the manually wired and auto wired messageReader get same result
+    assertEquals(allMessages, anotherAllMessages);
   }
 }

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
@@ -1,21 +1,15 @@
 package edu.wisc.my.messages.controller;
 
-import static org.junit.Assert.assertEquals;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import edu.wisc.my.messages.data.MessagesFromTextFile;
-import edu.wisc.my.messages.model.Message;
-import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.core.io.DefaultResourceLoader;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.http.MediaType;
-import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -44,25 +38,6 @@ public class MessagesControllerTest {
    */
   @Test
   public void dataIsValid() {
-
-    MockEnvironment mockEnv = new MockEnvironment();
-
-    // ToDo: It would be very cool is this value could automatically stay in sync
-    //  with the actual value in the application.properties file.
-    mockEnv.setProperty("message.source", "classpath:messages.json");
-
-    ResourceLoader defaultLoader = new DefaultResourceLoader();
-
-    MessagesFromTextFile messageReader = new MessagesFromTextFile();
-    messageReader.setEnv(mockEnv);
-    messageReader.setResourceLoader(defaultLoader);
-
-    List<Message> allMessages = messageReader.allMessages();
-
-    // use the Spring injected wired up MessageReader
-    List<Message> anotherAllMessages = this.messageReader.allMessages();
-
-    // assert that the manually wired and auto wired messageReader get same result
-    assertEquals(allMessages, anotherAllMessages);
+    this.messageReader.allMessages();
   }
 }

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
@@ -3,12 +3,16 @@ package edu.wisc.my.messages.controller;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import edu.wisc.my.messages.data.MessagesFromTextFile;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.http.MediaType;
+import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -27,5 +31,26 @@ public class MessagesControllerTest {
       .andExpect(status().isOk())
       .andExpect(content().contentTypeCompatibleWith("application/json"))
       .andExpect(content().json("{\"status\":\"up\"}"));
+  }
+
+  /**
+   * Test that the data in the incoming text file is actually valid.
+   */
+  @Test
+  public void dataIsValid() {
+
+    MockEnvironment mockEnv = new MockEnvironment();
+
+    // ToDo: It would be very cool is this value could automatically stay in sync
+    //  with the actual value in the application.properties file.
+    mockEnv.setProperty("message.source", "classpath:messages.json");
+
+    ResourceLoader defaultLoader = new DefaultResourceLoader();
+
+    MessagesFromTextFile messageReader = new MessagesFromTextFile();
+    messageReader.setEnv(mockEnv);
+    messageReader.setResourceLoader(defaultLoader);
+
+    messageReader.allMessages();
   }
 }

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
@@ -34,7 +34,8 @@ public class MessagesControllerTest {
   }
 
   /**
-   * Test that the data in the incoming text file is actually valid.
+   * Test that the autowired MessageReader successfully reads messages.
+   * This is an essential building block towards richer tests of the application-as-running.
    */
   @Test
   public void dataIsValid() {

--- a/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
+++ b/src/test/java/edu/wisc/my/messages/controller/MessagesControllerTest.java
@@ -34,8 +34,8 @@ public class MessagesControllerTest {
   }
 
   /**
-   * Test that the autowired MessageReader successfully reads messages.
-   * This is an essential building block towards richer tests of the application-as-running.
+   * Test that the autowired MessageReader successfully reads messages. This is an essential
+   * building block towards richer tests of the application-as-running.
    */
   @Test
   public void dataIsValid() {

--- a/src/test/java/edu/wisc/my/messages/data/MessagesFromTextFileTest.java
+++ b/src/test/java/edu/wisc/my/messages/data/MessagesFromTextFileTest.java
@@ -4,17 +4,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-
-import org.junit.Assert;
 import org.junit.Test;
-
-import org.springframework.mock.env.MockEnvironment;
-
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.mock.env.MockEnvironment;
 
 public class MessagesFromTextFileTest {
 

--- a/src/test/java/edu/wisc/my/messages/data/MessagesFromTextFileTest.java
+++ b/src/test/java/edu/wisc/my/messages/data/MessagesFromTextFileTest.java
@@ -26,11 +26,11 @@ public class MessagesFromTextFileTest {
   public void dataIsValid() {
 
     MockEnvironment mockEnv = new MockEnvironment();
-    
+
     // ToDo: It would be very cool is this value could automaticall stay in sync
     //  with the actual value in the application.properties file.
     mockEnv.setProperty("message.source", "classpath:messages.json");
-    
+
     ResourceLoader defaultLoader = new DefaultResourceLoader();
 
     MessagesFromTextFile messageReader = new MessagesFromTextFile();

--- a/src/test/java/edu/wisc/my/messages/data/MessagesFromTextFileTest.java
+++ b/src/test/java/edu/wisc/my/messages/data/MessagesFromTextFileTest.java
@@ -31,12 +31,9 @@ public class MessagesFromTextFileTest {
     MessagesFromTextFile messageReader = new MessagesFromTextFile();
     messageReader.setEnv(mockEnv);
     messageReader.setResourceLoader(defaultLoader);
-    try{
-       messageReader.allMessages();
-    } catch (Exception e) {
-      Assert.fail("Invalid incoming data in MessagesFromTextFile");
-    }
-  } 
+
+    messageReader.allMessages();
+  }
   /**
    * Test that an exception encountered in preparing to read the text file results in a throw from
    * the reader.

--- a/src/test/java/edu/wisc/my/messages/data/MessagesFromTextFileTest.java
+++ b/src/test/java/edu/wisc/my/messages/data/MessagesFromTextFileTest.java
@@ -13,27 +13,6 @@ import org.springframework.mock.env.MockEnvironment;
 
 public class MessagesFromTextFileTest {
 
-
-  /**
-   * Test that the data in the incoming text file is actually valid.
-   */
-  @Test
-  public void dataIsValid() {
-
-    MockEnvironment mockEnv = new MockEnvironment();
-
-    // ToDo: It would be very cool is this value could automatically stay in sync
-    //  with the actual value in the application.properties file.
-    mockEnv.setProperty("message.source", "classpath:messages.json");
-
-    ResourceLoader defaultLoader = new DefaultResourceLoader();
-
-    MessagesFromTextFile messageReader = new MessagesFromTextFile();
-    messageReader.setEnv(mockEnv);
-    messageReader.setResourceLoader(defaultLoader);
-
-    messageReader.allMessages();
-  }
   /**
    * Test that an exception encountered in preparing to read the text file results in a throw from
    * the reader.

--- a/src/test/java/edu/wisc/my/messages/data/MessagesFromTextFileTest.java
+++ b/src/test/java/edu/wisc/my/messages/data/MessagesFromTextFileTest.java
@@ -6,10 +6,8 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import org.junit.Test;
 import org.springframework.core.env.Environment;
-import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.mock.env.MockEnvironment;
 
 public class MessagesFromTextFileTest {
 

--- a/src/test/java/edu/wisc/my/messages/data/MessagesFromTextFileTest.java
+++ b/src/test/java/edu/wisc/my/messages/data/MessagesFromTextFileTest.java
@@ -22,7 +22,7 @@ public class MessagesFromTextFileTest {
 
     MockEnvironment mockEnv = new MockEnvironment();
 
-    // ToDo: It would be very cool is this value could automaticall stay in sync
+    // ToDo: It would be very cool is this value could automatically stay in sync
     //  with the actual value in the application.properties file.
     mockEnv.setProperty("message.source", "classpath:messages.json");
 

--- a/src/test/java/edu/wisc/my/messages/model/MessageFilterTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/MessageFilterTest.java
@@ -1,9 +1,13 @@
 package edu.wisc.my.messages.model;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.junit.Test;
 
@@ -37,6 +41,115 @@ public class MessageFilterTest {
     user.setGroups(groups);
 
     assertFalse(filter.test(user));
+  }
+
+  @Test
+  public void stringRepresentationContainsGoLiveDate() {
+    MessageFilter filter = new MessageFilter();
+    filter.setGoLiveDate("2018-02-24");
+    assertTrue(filter.toString().contains("2018-02-24"));
+  }
+
+  @Test
+  public void stringRepresentationContainsExpireDate() {
+    MessageFilter filter = new MessageFilter();
+    filter.setExpireDate("2018-02-24");
+    assertTrue(filter.toString().contains("2018-02-24"));
+  }
+
+  @Test
+  public void filtersWithSameGroupsAndDatesAreEqual() {
+
+    List<String> groupsListOne = new ArrayList<String>();
+    groupsListOne.add("some-group");
+    groupsListOne.add("some-other-group");
+
+    List<String> groupsListTwo = new ArrayList<String>();
+    groupsListTwo.addAll(groupsListOne);
+
+    MessageFilter filterOne = new MessageFilter();
+    filterOne.setGoLiveDate("2000-01-01");
+    filterOne.setExpireDate("2030-01-01");
+    filterOne.setGroups(groupsListOne);
+
+    MessageFilter filterTwo = new MessageFilter();
+    filterTwo.setGoLiveDate("2000-01-01");
+    filterTwo.setExpireDate("2030-01-01");
+    filterTwo.setGroups(groupsListOne);
+
+    assertEquals(filterOne.hashCode(), filterTwo.hashCode());
+    assertEquals(filterOne, filterTwo);
+  }
+
+  @Test
+  public void filtersWithDifferentGroupsAreNotEquall() {
+
+    List<String> groupsListOne = new ArrayList<String>();
+    groupsListOne.add("some-group");
+    groupsListOne.add("some-other-group");
+
+    List<String> groupsListTwo = new ArrayList<String>();
+    groupsListTwo.add("a-different-group");
+    groupsListTwo.add("never-seen-this-group-before");
+
+    MessageFilter filterOne = new MessageFilter();
+    filterOne.setGoLiveDate("2000-01-01");
+    filterOne.setExpireDate("2030-01-01");
+    filterOne.setGroups(groupsListOne);
+
+    MessageFilter filterTwo = new MessageFilter();
+    filterTwo.setGoLiveDate("2000-01-01");
+    filterTwo.setExpireDate("2030-01-01");
+    filterTwo.setGroups(groupsListOne);
+
+    assertNotEquals(filterOne, filterTwo);
+  }
+
+  @Test
+  public void filtersWithDifferentGoLiveDatesAreNotEqual() {
+
+    List<String> groupsListOne = new ArrayList<String>();
+    groupsListOne.add("some-group");
+    groupsListOne.add("some-other-group");
+
+    List<String> groupsListTwo = new ArrayList<String>();
+    groupsListTwo.addAll(groupsListOne);
+
+    MessageFilter filterOne = new MessageFilter();
+    filterOne.setGoLiveDate("2000-01-01");
+    filterOne.setExpireDate("2030-01-01");
+    filterOne.setGroups(groupsListOne);
+
+    MessageFilter filterTwo = new MessageFilter();
+    filterTwo.setGoLiveDate("2002-02-02");
+    filterTwo.setExpireDate("2030-01-01");
+    filterTwo.setGroups(groupsListOne);
+
+    assertEquals(filterOne.hashCode(), filterTwo.hashCode());
+    assertEquals(filterOne, filterTwo);
+  }
+
+  @Test
+  public void filtersWithDifferentExpireeDatesAreNotEqual() {
+
+    List<String> groupsListOne = new ArrayList<String>();
+    groupsListOne.add("some-group");
+    groupsListOne.add("some-other-group");
+
+    List<String> groupsListTwo = new ArrayList<String>();
+    groupsListTwo.addAll(groupsListOne);
+
+    MessageFilter filterOne = new MessageFilter();
+    filterOne.setGoLiveDate("2000-01-01");
+    filterOne.setExpireDate("2030-01-01");
+    filterOne.setGroups(groupsListOne);
+
+    MessageFilter filterTwo = new MessageFilter();
+    filterTwo.setGoLiveDate("2000-01-01");
+    filterTwo.setExpireDate("2044-04-01");
+    filterTwo.setGroups(groupsListOne);
+
+    assertNotEquals(filterOne, filterTwo);
   }
 
 }

--- a/src/test/java/edu/wisc/my/messages/model/MessageFilterTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/MessageFilterTest.java
@@ -58,6 +58,16 @@ public class MessageFilterTest {
   }
 
   @Test
+  public void stringRepresentationContainsGroups() {
+    MessageFilter filter = new MessageFilter();
+    filter.addGroupsItem("somegroup");
+    filter.addGroupsItem("some-other-group");
+
+    assertTrue(filter.toString().contains("somegroup"));
+    assertTrue(filter.toString().contains("some-other-group"));
+  }
+
+  @Test
   public void filtersWithSameGroupsAndDatesAreEqual() {
 
     List<String> groupsListOne = new ArrayList<String>();

--- a/src/test/java/edu/wisc/my/messages/model/MessageFilterTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/MessageFilterTest.java
@@ -7,7 +7,7 @@ import java.util.HashSet;
 import java.util.Set;
 import org.junit.Test;
 
-public class AudienceFilterTest {
+public class MessageFilterTest {
 
   @Test
   public void matchesWhenUserIsInAMatchingGroup() {

--- a/src/test/java/edu/wisc/my/messages/model/MessageFilterTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/MessageFilterTest.java
@@ -130,7 +130,7 @@ public class MessageFilterTest {
   }
 
   @Test
-  public void filtersWithDifferentExpireeDatesAreNotEqual() {
+  public void filtersWithDifferentExpireDatesAreNotEqual() {
 
     List<String> groupsListOne = new ArrayList<String>();
     groupsListOne.add("some-group");

--- a/src/test/java/edu/wisc/my/messages/model/MessageFilterTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/MessageFilterTest.java
@@ -125,8 +125,7 @@ public class MessageFilterTest {
     filterTwo.setExpireDate("2030-01-01");
     filterTwo.setGroups(groupsListOne);
 
-    assertEquals(filterOne.hashCode(), filterTwo.hashCode());
-    assertEquals(filterOne, filterTwo);
+    assertNotEquals(filterOne, filterTwo);
   }
 
   @Test

--- a/src/test/java/edu/wisc/my/messages/model/MessageFilterTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/MessageFilterTest.java
@@ -100,7 +100,7 @@ public class MessageFilterTest {
     MessageFilter filterTwo = new MessageFilter();
     filterTwo.setGoLiveDate("2000-01-01");
     filterTwo.setExpireDate("2030-01-01");
-    filterTwo.setGroups(groupsListOne);
+    filterTwo.setGroups(groupsListTwo);
 
     assertNotEquals(filterOne, filterTwo);
   }

--- a/src/test/java/edu/wisc/my/messages/model/MessageFilterTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/MessageFilterTest.java
@@ -82,7 +82,7 @@ public class MessageFilterTest {
   }
 
   @Test
-  public void filtersWithDifferentGroupsAreNotEquall() {
+  public void filtersWithDifferentGroupsAreNotEqual() {
 
     List<String> groupsListOne = new ArrayList<String>();
     groupsListOne.add("some-group");

--- a/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
@@ -67,7 +67,7 @@ public class ValidDateTest {
 
   /**
    * Test that messages that expire later today are not considered expired. That is, that expiration
-   * supports the THH:MM suffix on ISO date-times.   
+   * supports the THH:MM suffix on ISO date-times.
   @Test
   public void expiringLaterTodayIsNotExpired() throws InterruptedException {
 

--- a/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
+++ b/src/test/java/edu/wisc/my/messages/model/ValidDateTest.java
@@ -1,9 +1,7 @@
 package edu.wisc.my.messages.model;
 
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
-import java.time.LocalDateTime;
 import org.junit.Test;
 
 

--- a/src/test/java/edu/wisc/my/messages/service/ExpiredMessagePredicateTest.java
+++ b/src/test/java/edu/wisc/my/messages/service/ExpiredMessagePredicateTest.java
@@ -70,4 +70,14 @@ public class ExpiredMessagePredicateTest {
     assertFalse(expiredAsOfMillenium.test(preciselyExpiresAfterMillenium));
   }
 
+  @Test
+  public void messageWithNoFilterIsNotExpired() {
+    ExpiredMessagePredicate expiredAsOfMillenium =
+      new ExpiredMessagePredicate(LocalDateTime.parse("2000-01-01T00:00:00"));
+
+    Message messageWithNoFilter = new Message();
+
+    assertFalse(expiredAsOfMillenium.test(messageWithNoFilter));
+  }
+
 }

--- a/src/test/java/edu/wisc/my/messages/service/GoneLiveMessagePredicateTest.java
+++ b/src/test/java/edu/wisc/my/messages/service/GoneLiveMessagePredicateTest.java
@@ -100,4 +100,13 @@ public class GoneLiveMessagePredicateTest {
 
   }
 
+  @Test
+  public void messageWithNoFilterIsGoneLive() {
+    GoneLiveMessagePredicate predicate = new GoneLiveMessagePredicate(LocalDateTime.now());
+
+    Message messageWithNoFilter = new Message();
+
+    assertTrue(predicate.test(messageWithNoFilter));
+  }
+
 }

--- a/src/test/java/edu/wisc/my/messages/service/GoneLiveMessagePredicateTest.java
+++ b/src/test/java/edu/wisc/my/messages/service/GoneLiveMessagePredicateTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertTrue;
 
 import edu.wisc.my.messages.model.Message;
 import edu.wisc.my.messages.model.MessageFilter;
-
 import java.time.LocalDateTime;
 import org.junit.Test;
 

--- a/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
+++ b/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
@@ -7,14 +7,13 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
-import java.util.List;
-import org.junit.Test;
-
 import edu.wisc.my.messages.data.MessagesFromTextFile;
 import edu.wisc.my.messages.model.Message;
 import edu.wisc.my.messages.model.MessageFilter;
 import edu.wisc.my.messages.model.User;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
 
 public class MessagesServiceTest {
 

--- a/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
+++ b/src/test/java/edu/wisc/my/messages/service/MessagesServiceTest.java
@@ -106,11 +106,13 @@ public class MessagesServiceTest {
     expiredMessage.setFilter(expiredFilter);
     String longAgoDate = "1999-12-31";
     expiredFilter.setExpireDate(longAgoDate);
+    expiredMessage.setFilter(expiredFilter);
 
     Message preciselyExpiredMessage = new Message();
     MessageFilter preciselyExpiredMessageFilter = new MessageFilter();
     String preciseLongAgoDate = "1999-12-31T13:21:14";
     preciselyExpiredMessageFilter.setExpireDate(preciseLongAgoDate);
+    preciselyExpiredMessage.setFilter(preciselyExpiredMessageFilter);
 
     List<Message> unfilteredMessages = new ArrayList<>();
     unfilteredMessages.add(expiredMessage);


### PR DESCRIPTION
*This is a PR against a **feature branch** expressing feedback on that feature branch.* The path forward here might be to merge to that feature branch and then from there merge or squash to `master`. Of course, git being what it is, this branch could also be merged directly to `master`.

Sometimes the best way to express feedback on a changeset is in code commits.

This might or might not be one of those times, but regardless, a PR against the feature branch expressing changes as commits is how the feedback is expressed here. :smile:

Fix: whereas the feature branch this is in feedback to returned no messages for `/messages`, this branch

![one-message-all-alone](https://user-images.githubusercontent.com/952283/36673231-b3b11564-1ac7-11e8-9d1c-c17a80617de1.png)

+ Documents the underlying regression (null handling) with unit tests
+ Fixes the null handling
+ Slew of other feedback, expressed as tight commits.

----
Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements

----

[Definition of Done][]

<!-- Intended as a low-intrusion quick checklist reminder of Definition of Done.
     Routinely, take the opportunity to reflect and then tick off the did-the-right-thing-for items.
     Exceptionally, explain what's exceptional why.
-->

- [x] Documented (Doesn't add enough documentation, but no regression vis a vis feature branch contributing to)
- [x] Fails gracefully (improved `null` handling)
- [x] Tested (locally tested: `/messages` now returns the 1 has-no-group-filtering message I'd expect)
- [x] Secure (no security implications)
- [x] Adds no defects (adds tests; existing tests pass)
- [x] Shippable. (Path here is into a feature branch.)
- [x] Maintainable
- [x] Configurable (no less so)
- [x] Readable
- [x] Validates and sanitizes user input (none)
- [x] Styled (Google Style)

[Definition of Done]: https://goo.gl/4JG2Z5
