### PR TITLE
test: adds demo messages

### DIFF
--- a/src/main/resources/demoMessages,json
+++ b/src/main/resources/demoMessages,json
@@ -1,0 +1,102 @@
+{
+  "messages": [
+    { "id": "demo-low-priority-no-group-no-date",
+      "title": "No group. No date. Low priority.",
+      "titleShort": "No group. No date. Low priority.",
+      "description": "Test no group no date. Low priority.",
+      "descriptionShort": "No group. No date. Low priority.",
+      "messageType": "notification",
+      "featureImageUrl": null,
+      "priority": null,
+      "filter": {
+        "goLiveDate": null,
+        "expireDate": null,
+        "groups": []
+      },
+      "data": {
+        "dataUrl": null,
+        "dataObject": null,
+        "dataArrayFilter": null
+      },
+      "actionButton": {
+        "label": "Go",
+        "url": "http://www.google.com"
+      },
+      "moreInfoButton": null,
+      "confirmButton": null
+    },
+    {
+      "id": "demo-no-filter-at-all",
+      "title": "No group. No date. Low priority.",
+      "titleShort": "No group. No date. Low priority.",
+      "description": "Test no group no date. Low priority.",
+      "descriptionShort": "No group. No date. Low priority.",
+      "messageType": "notification",
+      "featureImageUrl": null,
+      "priority": null,
+      "data": {
+        "dataUrl": null,
+        "dataObject": null,
+        "dataArrayFilter": null
+      },
+      "actionButton": {
+        "label": "Go",
+        "url": "http://www.google.com"
+      },
+      "moreInfoButton": null,
+      "confirmButton": null
+    },
+    {
+      "id": "expired-the-day-Elvis-died",
+      "title": "No group. No date. Low priority.",
+      "titleShort": "No group. No date. Low priority.",
+      "description": "Test no group no date. Low priority.",
+      "descriptionShort": "No group. No date. Low priority.",
+      "messageType": "notification",
+      "featureImageUrl": null,
+      "priority": null,
+      "filter": {
+        "goLiveDate": null,
+        "expireDate": "1977-08-16",
+        "groups": []
+      },
+      "data": {
+        "dataUrl": null,
+        "dataObject": null,
+        "dataArrayFilter": null
+      },
+      "actionButton": {
+        "label": "Go",
+        "url": "http://www.google.com"
+      },
+      "moreInfoButton": null,
+      "confirmButton": null
+    },
+    {
+      "id": "will-not-go-live-until-Americas-tricentennial",
+      "title": "Happy three hundredth birthday America",
+      "titleShort": "USA 300",
+      "description": "Will not go live until after I am dead.",
+      "descriptionShort": "Not live yet.",
+      "messageType": "notification",
+      "featureImageUrl": null,
+      "priority": null,
+      "filter": {
+        "goLiveDate": "2076-07-04",
+        "expireDate": null,
+        "groups": []
+      },
+      "data": {
+        "dataUrl": null,
+        "dataObject": null,
+        "dataArrayFilter": null
+      },
+      "actionButton": {
+        "label": "Go",
+        "url": "http://www.google.com"
+      },
+      "moreInfoButton": null,
+      "confirmButton": null
+    }
+  ]
+}


### PR DESCRIPTION
adds an alternate file for demoable messages which will be unbuffetted by production winds of change


----
Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [X] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements

----

[Definition of Done][]

<!-- Intended as a low-intrusion quick checklist reminder of Definition of Done.
     Routinely, take the opportunity to reflect and then tick off the did-the-right-thing-for items.
     Exceptionally, explain what's exceptional why.
-->

- [ ] Documented
- [ ] Fails gracefully
- [ ] Tested
- [ ] Secure
- [ ] Adds no defects
- [ ] Shippable. Path is clear to promote to production
- [ ] Maintainable
- [ ] Configurable
- [ ] Readable
- [ ] Validates and sanitizes user input
- [ ] Styled (Google Style)

[Definition of Done]: https://goo.gl/4JG2Z5
